### PR TITLE
feat(cli): improve init command formatting

### DIFF
--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -433,7 +433,9 @@ export async function runInit(
 	console.log()
 
 	const scopeLabel = selectedScope === 'global' ? 'Global' : 'Project'
-	const installSpinner = ora(`Installing ${scopeLabel.toLowerCase()}...`).start()
+	const installSpinner = ora(
+		`Installing ${scopeLabel.toLowerCase()}...`,
+	).start()
 
 	const installResult = await installPlugin(selectedScope, projectDir, {
 		debug,


### PR DESCRIPTION
Refine the init command's visual presentation to match pickme's style:
- Use checkmark (✔) for done state, cyan pointer (❯) for selection
- Override Inquirer's default bold with plain text for cleaner look
- Update help text format with bullet separator (• q quit)
- Shorten header to "Install Navigator" with cleaner tagline
- Use accumulating success message pattern ("installed + plugin ready")
- Tighten spinner and error message text

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>