### PR TITLE
feat(cli): add viewport, color-scheme commands and snap -v flag

### DIFF
--- a/docs/cli-cleanup-codex-review.md
+++ b/docs/cli-cleanup-codex-review.md
@@ -1,0 +1,93 @@
+# CLI Cleanup Review (Codex)
+
+This is a focused review of the proposed CLI cleanup with suggestions around grouping, discoverability, and long term ergonomics.
+
+## 1) Command groupings (server, tab, mark)
+
+What looks good
+- Consolidating into `server`, `tab`, and `mark` reads clean and reduces top level sprawl.
+- Subcommand verbs are familiar (`start`, `stop`, `status`, `list`, `new`, `close`).
+
+Potential issues / questions
+- The doc uses `fw server` in the grouping section and `nav server` in the summary. Pick one and use it consistently in docs and help text.
+- `tab switch` is a bit wordy for the most common action; users will want a short path.
+- `mark rm` is consistent with Unix, but it may be less discoverable than `mark delete` or `mark remove` for newer users.
+
+Suggestions
+- Keep backward compatible aliases for at least one major release: `serve`, `status`, `tabs`, `tab`, `new-tab`, `close-tab`, `mark`, `markers`, `marker`, `marker-compare`, `marker-delete`, `tidy`. Emit a deprecation warning with the new form.
+- Consider allowing a shorthand for switching tabs: `nav tab <id>` as an alias for `nav tab switch <id>`.
+- Consider adding aliases for `mark rm` -> `mark delete` and `mark remove` to avoid friction. The canonical verb can remain `rm`.
+- Consider `mark show` as an alias for `mark get` since it reads better in human terms; keep `get` as the canonical (works with scripts).
+- If you keep `tab new`, decide whether `tab open` should be an alias. (Some users will try it.)
+
+## 2) `find` command with `--in` scoping
+
+What looks good
+- A dedicated `find` that avoids full snapshots will speed common flows.
+- The pattern of matching by text, role, label, placeholder, test id is consistent with automation tools.
+- `--in` scoping is a strong UX improvement for narrowing search without a full DOM snapshot.
+
+Potential issues / questions
+- `--in` is overloaded (ref, tag, CSS selector, text). Without a disambiguation strategy, the parser could guess wrong and users will hit surprising failures.
+- `find @e42` doubles as a "get details" command. That is convenient but a little semantically odd, since `find` normally implies a query.
+- It is not explicit whether matches are case sensitive, whether text is normalized (trim/collapse whitespace), or whether hidden elements are included.
+
+Suggestions
+- Add explicit prefixes for `--in` values to make parsing deterministic while keeping the existing shorthand:
+  - `--in ref:@e42`
+  - `--in tag:form`
+  - `--in css:.modal`
+  - `--in text:"Shopping Cart"`
+  Keep `@ref` and bare tag names as shorthand, but document the precedence order and fallbacks.
+- Consider `--in` accepting multiple scopes (AND): `--in ref:@e42 --in css:.row`.
+- Provide a stricter mode to avoid ambiguous results:
+  - `--one` -> error if 0 or >1 matches
+  - `--limit N` -> cap results for predictable output
+  - `--first` -> return the first match (deterministic ordering should be documented)
+- Clarify `find` defaults: case sensitivity, text normalization, and visibility. Optional flags: `--case-sensitive`, `--include-hidden`.
+- If you keep `find @e42` as a "ref inspect" shortcut, call that out explicitly, or consider `nav ref @e42` / `nav inspect @e42` as a clearer command and keep `find @e42` as an alias.
+
+## 3) `press` command with modifier support
+
+What looks good
+- A dedicated `press` command fills a real gap for keyboard driven UIs.
+- The proposed modifier syntax is simple and shell friendly.
+
+Potential issues / questions
+- Key naming varies across platforms and libraries (Playwright uses `Meta`, `Control`, `ArrowDown`, `Enter`, etc.).
+- Users will eventually want to press `-` or `+` or other punctuation. Those can be parsed as flags by accident.
+
+Suggestions
+- Normalize common aliases and document the canonical set:
+  - `cmd`, `meta`, `win` -> `Meta`
+  - `ctrl`, `control` -> `Control`
+  - `esc` -> `Escape`
+- Accept both hyphen and plus separators for combos: `ctrl-shift-p` and `ctrl+shift+p`.
+- Explicitly document escaping for edge cases: `nav press -- "-"` or `nav press -- "+"`.
+- Consider optional `--repeat N` and `--delay MS` to support quick repeated actions without loops.
+- If the underlying automation layer has a defined key list (ex: Playwright), link to it or include a short mapping table in docs.
+
+## 4) `interact` subcommands
+
+What looks good
+- Grouping the less common and stateful interactions under `interact` keeps the top level tidy.
+- Dialog pre registration is the right model for predictable automation.
+
+Potential issues / questions
+- `upload` commonly needs multiple files or directories and can be a frequent action in testing. It might deserve a more prominent alias.
+- Dialog handler lifecycle should be explicit: does it persist, and does it auto clear after use?
+
+Suggestions
+- Add `nav upload ...` as a top level alias to `nav interact upload ...` if you expect frequent use.
+- For `check` / `uncheck`, make it explicit that these are idempotent and will no-op if already in desired state.
+- For `dialog` handlers, document the lifecycle:
+  - default `once` vs `persist` (if it exists)
+  - what happens with multiple queued dialogs
+  - a `--once` flag could be helpful if persistence is the default
+- Consider `interact select @e1 "Option"` or `interact option @e1 3` for select elements (if not already covered by `fill` or `type`).
+- Consider a general `interact focus @e1` or `interact hover @e1` if you want to keep the top level small but still expose these actions.
+
+## Small consistency nits
+- In examples, use the same binary name (`nav` or `fw`) everywhere.
+- Make sure `mark diff` output and ordering are stable so it can be used in scripts.
+- If `clean` replaces `tidy`, keep `tidy` as a warning alias for a while.

--- a/docs/cli-cleanup.md
+++ b/docs/cli-cleanup.md
@@ -1,0 +1,297 @@
+# CLI Cleanup
+
+Consolidate and improve CLI command structure for consistency and discoverability.
+
+## Command Renames
+
+| Current | Proposed | Rationale |
+|---------|----------|-----------|
+| `init` | `install` | Clearer intent - installs Claude plugin |
+| `tidy` | `clean` | Standard convention |
+
+## Command Groupings
+
+### `server` subcommands
+
+Consolidate server management under `nav server`:
+
+| Current | Proposed |
+|---------|----------|
+| `serve` | `server start` |
+| `status` | `server status` |
+| (new) | `server stop` |
+
+### `tab` subcommands
+
+Consolidate tab management under `nav tab`:
+
+| Current | Proposed |
+|---------|----------|
+| `tabs` | `tab list` |
+| `tab <id>` | `tab <id>` (shorthand) or `tab switch <id>` |
+| `new-tab [url]` | `tab new [url]` |
+| `close-tab <id>` | `tab close <id>` |
+
+Note: `nav tab <id>` works as shorthand for `nav tab switch <id>` since switching is the most common action.
+
+### `mark` subcommands
+
+Consolidate marker management under `nav mark`:
+
+| Current | Proposed |
+|---------|----------|
+| `mark` | `mark save` |
+| `markers` | `mark list` |
+| `marker <id>` | `mark get <id>` |
+| `marker-compare <id1> <id2>` | `mark diff <id1> <id2>` |
+| `marker-delete <id>` | `mark remove <id>` |
+
+## Summary
+
+### Before (18 top-level commands)
+
+```
+nav init
+nav serve
+nav status
+nav tabs
+nav tab
+nav new-tab
+nav close-tab
+nav mark
+nav markers
+nav marker
+nav marker-compare
+nav marker-delete
+nav tidy
+nav doctor
+nav update
+nav uninstall
+nav watch
+nav session
+nav steps
+```
+
+### After (11 top-level commands + subcommands)
+
+```
+nav install
+nav server start|stop|status
+nav tab list|switch|new|close
+nav mark save|list|get|diff|remove
+nav clean
+nav doctor
+nav update
+nav uninstall
+nav watch
+nav session
+nav steps
+```
+
+## Ergonomic Improvements
+
+### `color-scheme` alias
+
+Add `system` as an alias for `no-preference` (clearer intent):
+
+```bash
+nav color-scheme system   # → sends 'no-preference' to agent-browser
+nav color-scheme light
+nav color-scheme dark
+```
+
+### `scroll` direction syntax
+
+The schema uses `x`/`y` but CLI already converts direction. Expose direction in schema:
+
+```bash
+nav scroll down 200      # Current (works)
+nav scroll down          # Default amount
+```
+
+Schema should accept both:
+- `{ action: 'scroll', direction: 'down', amount: 200 }` (ergonomic)
+- `{ action: 'scroll', x: 0, y: 200 }` (raw)
+
+## New Commands
+
+### `press` - Keyboard input
+
+Support single keys and key combinations (safely):
+
+```bash
+nav press Enter
+nav press Escape
+nav press Tab
+nav press cmd-k          # Command palette (Linear, VS Code, etc.)
+nav press ctrl-shift-p   # Another common binding
+nav press ArrowDown
+```
+
+**Modifier format**: `ctrl-`, `cmd-`, `shift-`, `alt-` (combinable)
+
+**Key normalization** (aliases accepted, canonical sent to Playwright):
+- `cmd`, `meta`, `win` → `Meta`
+- `ctrl`, `control` → `Control`
+- `esc` → `Escape`
+
+**Separator support**: Both `-` and `+` work:
+- `ctrl-shift-p` and `ctrl+shift+p` are equivalent
+
+**Edge cases**: Use `--` for punctuation keys:
+```bash
+nav press -- "-"         # Minus key
+nav press -- "+"         # Plus key
+```
+
+### `fill` - Instant form fill
+
+Alternative to `type` - sets value directly without simulating keystrokes:
+
+```bash
+nav fill @e1 "hello@example.com"    # Instant
+nav type @e1 "hello@example.com"    # Keystroke simulation (existing)
+```
+
+Use `fill` for speed, `type` when keystroke events matter (autocomplete, validation triggers).
+
+### `click` enhancements
+
+```bash
+nav click @e1                    # Left click (existing)
+nav click @e1 --double           # Double click
+nav click @e1 --right            # Right click (existing via --button)
+nav click @e1 --mod ctrl         # Ctrl+click (open in new tab, etc.)
+nav click @e1 --mod cmd          # Cmd+click
+nav click @e1 --mod shift        # Shift+click (extend selection)
+```
+
+### `interact` subcommands
+
+Group less common interaction actions:
+
+```bash
+nav interact check @e1           # Check checkbox
+nav interact uncheck @e1         # Uncheck checkbox
+nav interact upload @e1 ./file.png   # File upload
+nav interact dialog accept       # Accept next alert/confirm
+nav interact dialog dismiss      # Dismiss next alert/confirm
+nav interact dialog prompt "text"    # Answer next prompt with text
+nav interact dialog clear        # Clear handler (back to auto-dismiss)
+```
+
+**Idempotency**: `check` and `uncheck` are idempotent - they no-op if the checkbox is already in the desired state.
+
+**Dialog lifecycle**:
+- Handlers are **one-shot** by default (auto-cleared after handling one dialog)
+- Multiple queued dialogs require re-registering the handler
+- `dialog clear` removes any pending handler (returns to auto-dismiss)
+
+**Important**: Dialog handlers use a pre-registration pattern. Set the handler *before* the action that triggers the dialog:
+
+```bash
+nav interact dialog accept       # 1. Register handler (one-shot)
+nav click @submit-button         # 2. This triggers confirm() → auto-accepted
+# Handler now cleared - next dialog would auto-dismiss
+```
+
+### `find` - Element discovery
+
+Fast element lookup without full snap. Returns list if multiple matches.
+
+```bash
+nav find "Submit"                  # Find by visible text (partial match)
+nav find --exact "Submit"          # Exact text match
+nav find --role button             # Find by ARIA role
+nav find --role button "Submit"    # Role + text combo
+nav find --label "Email"           # Find by associated label
+nav find --placeholder "Search"    # Find by placeholder
+nav find --testid "submit-btn"     # Find by data-testid
+nav find @e42                      # Get details about existing ref
+```
+
+**Scoped search** - narrow down within a container:
+
+```bash
+nav find "Submit" --in-ref @e42           # Search within element ref
+nav find "Submit" --in-tag form           # Search within tag type
+nav find "Submit" --in-css ".modal"       # Search within CSS selector
+nav find "Submit" --in-css "#sidebar > nav"
+nav find "Delete" --in-tag form --role button  # Chained filters
+```
+
+**Scope flags**:
+- `--in-ref @e42` - Search within an element reference
+- `--in-tag form` - Search within all elements of a tag type
+- `--in-css ".modal"` - Search within elements matching CSS selector
+
+**Tag filtering** (filter results by tag, not scope):
+
+```bash
+nav find "Settings" --tag a               # Only links
+nav find "Submit" --tag button            # Only buttons
+nav find --tag input --in-tag form        # All inputs in forms
+```
+
+**State filtering**:
+
+```bash
+nav find "Submit" --visible               # Only visible elements
+nav find --tag input --enabled            # Only enabled inputs
+nav find --role checkbox --checked        # Only checked checkboxes
+nav find "Submit" --in-css ".modal" --visible  # Combined
+```
+
+Returns rich element info (array if multiple):
+
+```json
+[
+  {
+    "ref": "e42",
+    "text": "Submit",
+    "role": "button",
+    "tag": "button",
+    "box": { "x": 100, "y": 200, "width": 80, "height": 32 },
+    "visible": true,
+    "enabled": true,
+    "attributes": { "class": "btn-primary", "type": "submit" }
+  }
+]
+```
+
+**Scriptable workflows** - faster than screenshot analysis:
+
+```bash
+# Find and click without snap/screenshot
+nav find "Log in" | nav click      # Pipe first match to click
+
+# Conditional logic
+nav find --role alert              # Check for error messages
+nav find --label "Email" | nav fill "user@example.com"
+
+# Verify state
+nav find "Submit" --json | jq '.enabled'  # Is button enabled?
+
+# Count matches
+nav find --role listitem | wc -l   # How many items?
+```
+
+**Comparison:**
+
+| Approach | Steps | Latency |
+|----------|-------|---------|
+| Screenshot → Vision → Click | 3 | ~2-5s |
+| Snap → Parse → Click | 3 | ~500ms |
+| Find → Click | 2 | ~100ms |
+
+## Deferred
+
+### Auth persistence (`auth save`/`auth load`)
+
+Save and restore browser state (cookies, localStorage) for maintaining login across sessions. Deferred for later implementation.
+
+## Implementation Notes
+
+- Keep backward compatibility aliases for deprecated commands (warn on use)
+- Update CLAUDE.md and plugin docs
+- Update MCP action mappings if affected

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
 	"types": "./dist/index.d.ts",
 	"scripts": {
 		"build": "tsc && bun run build:bundle",
-		"build:bundle": "bun build ./src/index.ts --outdir ./dist --target bun",
+		"build:bundle": "bun build ./src/index.ts --outdir ./dist --target bun --sourcemap=external",
 		"dev": "bun --watch ./src/index.ts",
 		"start": "bun ./src/index.ts",
 		"typecheck": "tsc --noEmit"

--- a/packages/cli/src/commands/display.ts
+++ b/packages/cli/src/commands/display.ts
@@ -1,0 +1,138 @@
+/**
+ * Display Commands
+ *
+ * viewport, color-scheme
+ */
+
+import {
+	type ColorSchemeInput,
+	normalizeColorScheme,
+} from '@outfitter/navigator-core'
+import type { Command } from 'commander'
+import type { NavigatorClient } from '../client.js'
+
+/** Viewport presets with their dimensions */
+const VIEWPORT_PRESETS = {
+	mobile: { width: 375, height: 667 },
+	tablet: { width: 768, height: 1024 },
+	desktop: { width: 1920, height: 1080 },
+} as const
+
+type ViewportPreset = keyof typeof VIEWPORT_PRESETS
+
+export function registerDisplayCommands(
+	program: Command,
+	getClient: () => NavigatorClient,
+): void {
+	// nav viewport <width> <height> or nav viewport --preset <name>
+	program
+		.command('viewport [width] [height]')
+		.description('Set viewport size')
+		.option('-p, --preset <name>', 'Use preset: mobile, tablet, desktop')
+		.action(
+			async (
+				widthStr?: string,
+				heightStr?: string,
+				options?: { preset?: string },
+			) => {
+				const client = getClient()
+
+				// Handle preset
+				if (options?.preset) {
+					const presetName = options.preset as ViewportPreset
+					if (!(presetName in VIEWPORT_PRESETS)) {
+						console.error(
+							`Invalid preset: ${options.preset}. Use: mobile, tablet, desktop`,
+						)
+						process.exitCode = 1
+						return
+					}
+
+					const preset = VIEWPORT_PRESETS[presetName]
+					try {
+						await client.execute({
+							action: 'viewport',
+							width: preset.width,
+							height: preset.height,
+						})
+						console.log(
+							`Viewport set to ${presetName}: ${preset.width}x${preset.height}`,
+						)
+					} catch (error) {
+						console.error(
+							`Failed to set viewport: ${error instanceof Error ? error.message : String(error)}`,
+						)
+						process.exitCode = 1
+					}
+					return
+				}
+
+				// Handle explicit dimensions
+				if (!widthStr || !heightStr) {
+					console.error(
+						'Usage: nav viewport <width> <height> or nav viewport --preset <name>',
+					)
+					process.exitCode = 1
+					return
+				}
+
+				const width = Number(widthStr)
+				const height = Number(heightStr)
+
+				if (Number.isNaN(width) || Number.isNaN(height)) {
+					console.error('Width and height must be valid numbers')
+					process.exitCode = 1
+					return
+				}
+
+				try {
+					await client.execute({
+						action: 'viewport',
+						width,
+						height,
+					})
+					console.log(`Viewport set to: ${width}x${height}`)
+				} catch (error) {
+					console.error(
+						`Failed to set viewport: ${error instanceof Error ? error.message : String(error)}`,
+					)
+					process.exitCode = 1
+				}
+			},
+		)
+
+	// nav color-scheme <scheme>
+	program
+		.command('color-scheme <scheme>')
+		.description('Set color scheme: light, dark, system (or no-preference)')
+		.action(async (scheme: string) => {
+			const client = getClient()
+
+			const validSchemes = ['light', 'dark', 'system', 'no-preference']
+			if (!validSchemes.includes(scheme)) {
+				console.error(
+					`Invalid scheme: ${scheme}. Use: ${validSchemes.join(', ')}`,
+				)
+				process.exitCode = 1
+				return
+			}
+
+			// Normalize input (e.g., 'system' -> 'no-preference')
+			const normalized = normalizeColorScheme(scheme as ColorSchemeInput)
+
+			try {
+				await client.execute({
+					action: 'colorScheme',
+					scheme: normalized,
+				})
+				console.log(
+					`Color scheme set to: ${scheme}${scheme !== normalized ? ` (${normalized})` : ''}`,
+				)
+			} catch (error) {
+				console.error(
+					`Failed to set color scheme: ${error instanceof Error ? error.message : String(error)}`,
+				)
+				process.exitCode = 1
+			}
+		})
+}

--- a/packages/cli/src/commands/interaction.ts
+++ b/packages/cli/src/commands/interaction.ts
@@ -44,6 +44,7 @@ export function registerInteractionCommands(
 		.command('snap')
 		.description('Snapshot page with element refs')
 		.option('-i, --interactive', 'Interactive elements only')
+		.option('-v, --visible', 'Visible elements only (in viewport)')
 		.option('-c, --compact', 'Compact output')
 		.option('-d, --depth <number>', 'Max depth')
 		.option('-s, --selector <selector>', 'Scope to selector')
@@ -55,6 +56,7 @@ export function registerInteractionCommands(
 			}>({
 				action: 'snap',
 				interactive: options.interactive,
+				visibleOnly: options.visible,
 				compact: options.compact,
 				depth: options.depth ? Number(options.depth) : undefined,
 				selector: options.selector,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Command } from 'commander'
 import { type ClientOptions, createClient } from './client.js'
+import { registerDisplayCommands } from './commands/display.js'
 import { registerDoctorCommand } from './commands/doctor.js'
 import { registerInteractionCommands } from './commands/interaction.js'
 import { registerMarkerCommands } from './commands/markers.js'
@@ -84,6 +85,9 @@ registerNavigationCommands(program, getClient)
 
 // Interaction: snap, click, type, select, hover, scroll, screenshot
 registerInteractionCommands(program, getClient)
+
+// Display: viewport, color-scheme
+registerDisplayCommands(program, getClient)
 
 // Markers: mark, markers, marker
 registerMarkerCommands(program, getClient)

--- a/packages/core/src/schema/action.ts
+++ b/packages/core/src/schema/action.ts
@@ -162,6 +162,7 @@ const snapAction = z.object({
 	compact: z.boolean().optional(),
 	depth: z.number().optional(),
 	selector: z.string().optional(),
+	visibleOnly: z.boolean().optional(),
 })
 
 const htmlAction = z.object({

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -169,6 +169,7 @@ const snapAction = z.object({
 	action: z.literal('snap'),
 	tab: tabRefSchema.optional(),
 	interactive: z.boolean().optional().describe('Interactive elements only'),
+	visibleOnly: z.boolean().optional().describe('Show only visible elements'),
 	compact: z.boolean().optional().describe('Compact tree output'),
 	depth: z.number().int().min(0).optional().describe('Max depth for output'),
 	selector: selectorSchema.optional().describe('Scope snap to selector'),

--- a/packages/server/src/actions/executor.ts
+++ b/packages/server/src/actions/executor.ts
@@ -647,6 +647,7 @@ export class ActionExecutor {
 			compact?: boolean | undefined
 			depth?: number | undefined
 			selector?: string | undefined
+			visibleOnly?: boolean | undefined
 		},
 	): Promise<ActionResult> {
 		if (this.isPairedActive()) {
@@ -721,6 +722,7 @@ export class ActionExecutor {
 			compact?: boolean | undefined
 			depth?: number | undefined
 			selector?: string | undefined
+			visibleOnly?: boolean | undefined
 		},
 	): Promise<ActionResult> {
 		const interactive = options.interactive ?? mode === 'input_fields'
@@ -733,6 +735,7 @@ export class ActionExecutor {
 			compact: options.compact,
 			maxDepth: options.depth,
 			selector: options.selector,
+			visibleOnly: options.visibleOnly,
 		})
 
 		if (!(response.success && response.data?.snapshot)) {


### PR DESCRIPTION
## Summary

- Add `nav viewport <w> <h>` command with `--preset` option (mobile/tablet/desktop)
- Add `nav color-scheme <scheme>` command (dark/light/no-preference)
- Add `-v/--visible` flag to snap command for visible-only elements
- Fix sourcemap warning by using external sourcemaps
- Add CLI cleanup planning docs

## New Commands

```bash
nav viewport 1920 1080           # Set exact dimensions
nav viewport --preset mobile     # Use preset (375x667)
nav viewport --preset tablet     # Use preset (768x1024)
nav viewport --preset desktop    # Use preset (1920x1080)

nav color-scheme dark            # Set dark mode
nav color-scheme light           # Set light mode

nav snap -v                      # Snap visible elements only
```

## Planning Docs

- `docs/cli-cleanup.md` - CLI restructuring plan (command groupings, new commands)
- `docs/cli-cleanup-codex-review.md` - External review feedback

## Test Plan

- [x] Manual testing of viewport/color-scheme commands
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.ai/code)