### PR TITLE
feat(core): CLI cleanup utilities and schemas (TDD)

### DIFF
--- a/packages/core/src/schema/action.ts
+++ b/packages/core/src/schema/action.ts
@@ -116,6 +116,71 @@ const scrollAction = z.object({
 	tab: tabRefSchema.optional(),
 })
 
+const pressAction = z.object({
+	action: z.literal('press'),
+	key: z.string().min(1),
+	tab: tabRefSchema.optional(),
+})
+
+const fillAction = z.object({
+	action: z.literal('fill'),
+	ref: z.string().regex(elementRefPattern).optional(),
+	selector: z.string().optional(),
+	value: z.string(),
+	tab: tabRefSchema.optional(),
+})
+
+const findAction = z.object({
+	action: z.literal('find'),
+	// Search criteria
+	text: z.string().optional(),
+	exact: z.boolean().optional(),
+	role: z.string().optional(),
+	label: z.string().optional(),
+	placeholder: z.string().optional(),
+	testid: z.string().optional(),
+	ref: z.string().regex(elementRefPattern).optional(),
+	// Scoping
+	inRef: z.string().optional(),
+	inCss: z.string().optional(),
+	inTag: z.string().optional(),
+	// Filtering
+	tag: z.string().optional(),
+	visible: z.boolean().optional(),
+	enabled: z.boolean().optional(),
+	checked: z.boolean().optional(),
+	tab: tabRefSchema.optional(),
+})
+
+const checkAction = z.object({
+	action: z.literal('check'),
+	ref: z.string().regex(elementRefPattern).optional(),
+	selector: z.string().optional(),
+	tab: tabRefSchema.optional(),
+})
+
+const uncheckAction = z.object({
+	action: z.literal('uncheck'),
+	ref: z.string().regex(elementRefPattern).optional(),
+	selector: z.string().optional(),
+	tab: tabRefSchema.optional(),
+})
+
+const uploadAction = z.object({
+	action: z.literal('upload'),
+	ref: z.string().regex(elementRefPattern).optional(),
+	selector: z.string().optional(),
+	files: z.array(z.string()).min(1),
+	tab: tabRefSchema.optional(),
+})
+
+const dialogAction = z.object({
+	action: z.literal('dialog'),
+	handler: z.enum(['accept', 'dismiss', 'prompt', 'clear']),
+	text: z.string().optional(),
+	tab: tabRefSchema.optional(),
+})
+
 // ============================================================================
 // Wait Actions
 // ============================================================================
@@ -283,7 +348,7 @@ const stepsAction = z.object({
 // Discriminated Union
 // ============================================================================
 
-export const ActionSchema = z.discriminatedUnion('action', [
+const baseActionSchema = z.discriminatedUnion('action', [
 	// Navigation
 	navigateAction,
 	backAction,
@@ -301,6 +366,13 @@ export const ActionSchema = z.discriminatedUnion('action', [
 	hoverAction,
 	focusAction,
 	scrollAction,
+	pressAction,
+	fillAction,
+	findAction,
+	checkAction,
+	uncheckAction,
+	uploadAction,
+	dialogAction,
 	// Wait
 	waitForAction,
 	waitForNavigationAction,
@@ -329,6 +401,18 @@ export const ActionSchema = z.discriminatedUnion('action', [
 	stepsAction,
 ])
 
+// Add cross-field validation for actions that require ref or selector
+export const ActionSchema = baseActionSchema.superRefine((data, ctx) => {
+	if (data.action === 'check' || data.action === 'uncheck') {
+		if (data.ref === undefined && data.selector === undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'Either ref or selector is required',
+			})
+		}
+	}
+})
+
 export type Action = z.infer<typeof ActionSchema>
 
 // Type aliases for specific actions
@@ -338,6 +422,13 @@ export type TypeAction = z.infer<typeof typeAction>
 export type SnapAction = z.infer<typeof snapAction>
 export type MarkerAction = z.infer<typeof markerAction>
 export type ModeAction = z.infer<typeof modeAction>
+export type PressAction = z.infer<typeof pressAction>
+export type FillAction = z.infer<typeof fillAction>
+export type FindAction = z.infer<typeof findAction>
+export type CheckAction = z.infer<typeof checkAction>
+export type UncheckAction = z.infer<typeof uncheckAction>
+export type UploadAction = z.infer<typeof uploadAction>
+export type DialogAction = z.infer<typeof dialogAction>
 
 // Browser mode type (uses 'paired' instead of 'guided')
 export type BrowserMode = 'headless' | 'windowed' | 'paired'

--- a/packages/core/src/utils/color-scheme.ts
+++ b/packages/core/src/utils/color-scheme.ts
@@ -1,0 +1,27 @@
+/**
+ * Color scheme normalization utilities
+ *
+ * Normalizes user-friendly color scheme inputs to Playwright-compatible values.
+ */
+
+export type ColorSchemeInput = 'light' | 'dark' | 'system' | 'no-preference'
+export type ColorSchemeOutput = 'light' | 'dark' | 'no-preference'
+
+/**
+ * Normalize a color scheme input to a Playwright-compatible value
+ *
+ * @param scheme - User input color scheme
+ * @returns Playwright-compatible color scheme
+ *
+ * @example
+ * normalizeColorScheme('system') // => 'no-preference'
+ * normalizeColorScheme('light') // => 'light'
+ */
+export function normalizeColorScheme(
+	scheme: ColorSchemeInput,
+): ColorSchemeOutput {
+	if (scheme === 'system') {
+		return 'no-preference'
+	}
+	return scheme
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Core utilities barrel export
+ */
+
+export { parseKeyCombo, type KeyCombo } from './keys'
+export {
+	normalizeColorScheme,
+	type ColorSchemeInput,
+	type ColorSchemeOutput,
+} from './color-scheme'

--- a/packages/core/src/utils/keys.ts
+++ b/packages/core/src/utils/keys.ts
@@ -1,0 +1,62 @@
+/**
+ * Key combo parsing utilities
+ *
+ * Parses keyboard shortcut strings like "ctrl-k" or "cmd+shift+p"
+ * into structured KeyCombo objects for use with Playwright.
+ */
+
+export interface KeyCombo {
+	key: string
+	modifiers: string[]
+}
+
+/**
+ * Parse a key combo string into its components
+ *
+ * @param combo - Key combo string like "ctrl-k", "cmd+shift+p", "Enter"
+ * @returns Parsed KeyCombo with key and modifiers
+ *
+ * @example
+ * parseKeyCombo('Enter') // => { key: 'Enter', modifiers: [] }
+ * parseKeyCombo('ctrl-k') // => { key: 'k', modifiers: ['Control'] }
+ * parseKeyCombo('cmd-shift-p') // => { key: 'p', modifiers: ['Meta', 'Shift'] }
+ */
+// Modifier key normalization map (lowercase input -> Playwright modifier)
+const modifierMap: Record<string, string> = {
+	cmd: 'Meta',
+	meta: 'Meta',
+	win: 'Meta',
+	ctrl: 'Control',
+	control: 'Control',
+	alt: 'Alt',
+	option: 'Alt',
+	shift: 'Shift',
+}
+
+// Key normalization map (lowercase input -> Playwright key)
+const keyMap: Record<string, string> = {
+	esc: 'Escape',
+}
+
+export function parseKeyCombo(combo: string): KeyCombo {
+	// Split by either - or + (supports both ctrl-k and ctrl+k)
+	const parts = combo.split(/[-+]/)
+
+	// Last part is the key, everything before is modifiers
+	// split() always returns at least one element for non-empty strings
+	const rawKey = parts.at(-1) ?? combo
+	const rawModifiers = parts.slice(0, -1)
+
+	// Normalize the key
+	const normalizedKey = keyMap[rawKey.toLowerCase()] ?? rawKey
+
+	// Normalize and filter modifiers
+	const modifiers = rawModifiers
+		.map((mod) => modifierMap[mod.toLowerCase()])
+		.filter((mod): mod is string => mod !== undefined)
+
+	return {
+		key: normalizedKey,
+		modifiers,
+	}
+}

--- a/packages/core/tests/schema/action.test.ts
+++ b/packages/core/tests/schema/action.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, test } from 'bun:test'
+import { ActionSchema } from '../../src/schema/action'
+
+/**
+ * Tests for new action schemas defined in cli-cleanup.md
+ *
+ * These tests will fail until the action schemas are implemented.
+ * They define the expected shape of the new actions.
+ */
+
+describe('ActionSchema - new actions', () => {
+	describe('pressAction', () => {
+		test('parses valid press action with single key', () => {
+			const result = ActionSchema.safeParse({
+				action: 'press',
+				key: 'Enter',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid press action with key combo', () => {
+			const result = ActionSchema.safeParse({
+				action: 'press',
+				key: 'ctrl-k',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('rejects press action with empty key', () => {
+			const result = ActionSchema.safeParse({
+				action: 'press',
+				key: '',
+			})
+			expect(result.success).toBe(false)
+		})
+
+		test('rejects press action without key', () => {
+			const result = ActionSchema.safeParse({
+				action: 'press',
+			})
+			expect(result.success).toBe(false)
+		})
+	})
+
+	describe('fillAction', () => {
+		test('parses valid fill action with ref', () => {
+			const result = ActionSchema.safeParse({
+				action: 'fill',
+				ref: '@e1',
+				value: 'test@example.com',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid fill action with selector', () => {
+			const result = ActionSchema.safeParse({
+				action: 'fill',
+				selector: '#email',
+				value: 'test@example.com',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses fill action with empty value', () => {
+			const result = ActionSchema.safeParse({
+				action: 'fill',
+				ref: '@e1',
+				value: '',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('rejects fill action without value', () => {
+			const result = ActionSchema.safeParse({
+				action: 'fill',
+				ref: '@e1',
+			})
+			expect(result.success).toBe(false)
+		})
+	})
+
+	describe('findAction', () => {
+		test('parses valid find action with text', () => {
+			const result = ActionSchema.safeParse({
+				action: 'find',
+				text: 'Submit',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses find action with exact match', () => {
+			const result = ActionSchema.safeParse({
+				action: 'find',
+				text: 'Submit',
+				exact: true,
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses find action with role', () => {
+			const result = ActionSchema.safeParse({
+				action: 'find',
+				role: 'button',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses find action with role and text', () => {
+			const result = ActionSchema.safeParse({
+				action: 'find',
+				role: 'button',
+				text: 'Submit',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses find action with label', () => {
+			const result = ActionSchema.safeParse({
+				action: 'find',
+				label: 'Email',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses find action with placeholder', () => {
+			const result = ActionSchema.safeParse({
+				action: 'find',
+				placeholder: 'Search...',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses find action with testid', () => {
+			const result = ActionSchema.safeParse({
+				action: 'find',
+				testid: 'submit-btn',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses find action with ref lookup', () => {
+			const result = ActionSchema.safeParse({
+				action: 'find',
+				ref: '@e42',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		describe('scoped search', () => {
+			test('parses find action with inRef scope', () => {
+				const result = ActionSchema.safeParse({
+					action: 'find',
+					text: 'Submit',
+					inRef: '@e42',
+				})
+				expect(result.success).toBe(true)
+			})
+
+			test('parses find action with inCss scope', () => {
+				const result = ActionSchema.safeParse({
+					action: 'find',
+					text: 'Submit',
+					inCss: '.modal',
+				})
+				expect(result.success).toBe(true)
+			})
+
+			test('parses find action with inTag scope', () => {
+				const result = ActionSchema.safeParse({
+					action: 'find',
+					text: 'Submit',
+					inTag: 'form',
+				})
+				expect(result.success).toBe(true)
+			})
+		})
+
+		describe('filters', () => {
+			test('parses find action with tag filter', () => {
+				const result = ActionSchema.safeParse({
+					action: 'find',
+					text: 'Settings',
+					tag: 'a',
+				})
+				expect(result.success).toBe(true)
+			})
+
+			test('parses find action with visible filter', () => {
+				const result = ActionSchema.safeParse({
+					action: 'find',
+					text: 'Submit',
+					visible: true,
+				})
+				expect(result.success).toBe(true)
+			})
+
+			test('parses find action with enabled filter', () => {
+				const result = ActionSchema.safeParse({
+					action: 'find',
+					tag: 'input',
+					enabled: true,
+				})
+				expect(result.success).toBe(true)
+			})
+
+			test('parses find action with checked filter', () => {
+				const result = ActionSchema.safeParse({
+					action: 'find',
+					role: 'checkbox',
+					checked: true,
+				})
+				expect(result.success).toBe(true)
+			})
+
+			test('parses find action with combined scope and filters', () => {
+				const result = ActionSchema.safeParse({
+					action: 'find',
+					text: 'Submit',
+					inCss: '.modal',
+					visible: true,
+				})
+				expect(result.success).toBe(true)
+			})
+		})
+	})
+
+	describe('checkAction', () => {
+		test('parses valid check action with ref', () => {
+			const result = ActionSchema.safeParse({
+				action: 'check',
+				ref: '@e1',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid check action with selector', () => {
+			const result = ActionSchema.safeParse({
+				action: 'check',
+				selector: '#agree',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('rejects check action without ref or selector', () => {
+			const result = ActionSchema.safeParse({
+				action: 'check',
+			})
+			expect(result.success).toBe(false)
+		})
+	})
+
+	describe('uncheckAction', () => {
+		test('parses valid uncheck action with ref', () => {
+			const result = ActionSchema.safeParse({
+				action: 'uncheck',
+				ref: '@e1',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid uncheck action with selector', () => {
+			const result = ActionSchema.safeParse({
+				action: 'uncheck',
+				selector: '#newsletter',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('rejects uncheck action without ref or selector', () => {
+			const result = ActionSchema.safeParse({
+				action: 'uncheck',
+			})
+			expect(result.success).toBe(false)
+		})
+	})
+
+	describe('uploadAction', () => {
+		test('parses valid upload action with single file', () => {
+			const result = ActionSchema.safeParse({
+				action: 'upload',
+				ref: '@e1',
+				files: ['./file.png'],
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid upload action with multiple files', () => {
+			const result = ActionSchema.safeParse({
+				action: 'upload',
+				ref: '@e1',
+				files: ['./file1.png', './file2.jpg'],
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid upload action with selector', () => {
+			const result = ActionSchema.safeParse({
+				action: 'upload',
+				selector: 'input[type="file"]',
+				files: ['./photo.jpg'],
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('rejects upload action with empty files array', () => {
+			const result = ActionSchema.safeParse({
+				action: 'upload',
+				ref: '@e1',
+				files: [],
+			})
+			expect(result.success).toBe(false)
+		})
+
+		test('rejects upload action without files', () => {
+			const result = ActionSchema.safeParse({
+				action: 'upload',
+				ref: '@e1',
+			})
+			expect(result.success).toBe(false)
+		})
+	})
+
+	describe('dialogAction', () => {
+		test('parses valid dialog accept action', () => {
+			const result = ActionSchema.safeParse({
+				action: 'dialog',
+				handler: 'accept',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid dialog dismiss action', () => {
+			const result = ActionSchema.safeParse({
+				action: 'dialog',
+				handler: 'dismiss',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid dialog prompt action with text', () => {
+			const result = ActionSchema.safeParse({
+				action: 'dialog',
+				handler: 'prompt',
+				text: 'answer',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('parses valid dialog clear action', () => {
+			const result = ActionSchema.safeParse({
+				action: 'dialog',
+				handler: 'clear',
+			})
+			expect(result.success).toBe(true)
+		})
+
+		test('rejects dialog action without handler', () => {
+			const result = ActionSchema.safeParse({
+				action: 'dialog',
+			})
+			expect(result.success).toBe(false)
+		})
+
+		test('rejects dialog action with invalid handler', () => {
+			const result = ActionSchema.safeParse({
+				action: 'dialog',
+				handler: 'invalid',
+			})
+			expect(result.success).toBe(false)
+		})
+	})
+})

--- a/packages/core/tests/utils/color-scheme.test.ts
+++ b/packages/core/tests/utils/color-scheme.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { normalizeColorScheme } from '../../src/utils/color-scheme'
+
+describe('normalizeColorScheme', () => {
+	describe('pass-through values', () => {
+		test('returns light unchanged', () => {
+			const result = normalizeColorScheme('light')
+			expect(result).toBe('light')
+		})
+
+		test('returns dark unchanged', () => {
+			const result = normalizeColorScheme('dark')
+			expect(result).toBe('dark')
+		})
+
+		test('returns no-preference unchanged', () => {
+			const result = normalizeColorScheme('no-preference')
+			expect(result).toBe('no-preference')
+		})
+	})
+
+	describe('alias normalization', () => {
+		test('normalizes system to no-preference', () => {
+			const result = normalizeColorScheme('system')
+			expect(result).toBe('no-preference')
+		})
+	})
+})

--- a/packages/core/tests/utils/keys.test.ts
+++ b/packages/core/tests/utils/keys.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test'
+import { parseKeyCombo } from '../../src/utils/keys'
+
+describe('parseKeyCombo', () => {
+	describe('single keys without modifiers', () => {
+		test('parses Enter key', () => {
+			const result = parseKeyCombo('Enter')
+			expect(result).toEqual({ key: 'Enter', modifiers: [] })
+		})
+
+		test('parses Tab key', () => {
+			const result = parseKeyCombo('Tab')
+			expect(result).toEqual({ key: 'Tab', modifiers: [] })
+		})
+
+		test('parses ArrowDown key', () => {
+			const result = parseKeyCombo('ArrowDown')
+			expect(result).toEqual({ key: 'ArrowDown', modifiers: [] })
+		})
+	})
+
+	describe('key normalization', () => {
+		test('normalizes esc to Escape', () => {
+			const result = parseKeyCombo('esc')
+			expect(result).toEqual({ key: 'Escape', modifiers: [] })
+		})
+
+		test('normalizes Esc to Escape (case insensitive)', () => {
+			const result = parseKeyCombo('Esc')
+			expect(result).toEqual({ key: 'Escape', modifiers: [] })
+		})
+	})
+
+	describe('modifier key normalization', () => {
+		test('parses ctrl-k with hyphen separator', () => {
+			const result = parseKeyCombo('ctrl-k')
+			expect(result).toEqual({ key: 'k', modifiers: ['Control'] })
+		})
+
+		test('parses ctrl+k with plus separator', () => {
+			const result = parseKeyCombo('ctrl+k')
+			expect(result).toEqual({ key: 'k', modifiers: ['Control'] })
+		})
+
+		test('normalizes cmd to Meta', () => {
+			const result = parseKeyCombo('cmd-k')
+			expect(result).toEqual({ key: 'k', modifiers: ['Meta'] })
+		})
+
+		test('normalizes meta to Meta', () => {
+			const result = parseKeyCombo('meta-k')
+			expect(result).toEqual({ key: 'k', modifiers: ['Meta'] })
+		})
+
+		test('normalizes win to Meta', () => {
+			const result = parseKeyCombo('win-k')
+			expect(result).toEqual({ key: 'k', modifiers: ['Meta'] })
+		})
+
+		test('normalizes control to Control', () => {
+			const result = parseKeyCombo('control-k')
+			expect(result).toEqual({ key: 'k', modifiers: ['Control'] })
+		})
+
+		test('normalizes alt to Alt', () => {
+			const result = parseKeyCombo('alt-k')
+			expect(result).toEqual({ key: 'k', modifiers: ['Alt'] })
+		})
+
+		test('normalizes shift to Shift', () => {
+			const result = parseKeyCombo('shift-k')
+			expect(result).toEqual({ key: 'k', modifiers: ['Shift'] })
+		})
+	})
+
+	describe('multiple modifiers', () => {
+		test('parses ctrl-shift-p', () => {
+			const result = parseKeyCombo('ctrl-shift-p')
+			expect(result).toEqual({ key: 'p', modifiers: ['Control', 'Shift'] })
+		})
+
+		test('parses cmd-shift-p', () => {
+			const result = parseKeyCombo('cmd-shift-p')
+			expect(result).toEqual({ key: 'p', modifiers: ['Meta', 'Shift'] })
+		})
+
+		test('parses ctrl+alt+del', () => {
+			const result = parseKeyCombo('ctrl+alt+del')
+			expect(result).toEqual({ key: 'del', modifiers: ['Control', 'Alt'] })
+		})
+
+		test('parses cmd-shift-alt-k', () => {
+			const result = parseKeyCombo('cmd-shift-alt-k')
+			expect(result).toEqual({
+				key: 'k',
+				modifiers: ['Meta', 'Shift', 'Alt'],
+			})
+		})
+	})
+
+	describe('case handling', () => {
+		test('handles uppercase modifiers', () => {
+			const result = parseKeyCombo('Ctrl-K')
+			expect(result).toEqual({ key: 'K', modifiers: ['Control'] })
+		})
+
+		test('handles mixed case modifiers', () => {
+			const result = parseKeyCombo('CMD-SHIFT-P')
+			expect(result).toEqual({ key: 'P', modifiers: ['Meta', 'Shift'] })
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Add `parseKeyCombo()` utility for parsing keyboard shortcuts (`ctrl-k`, `cmd-shift-p`)
- Add `normalizeColorScheme()` utility for `system` → `no-preference` alias
- Add 7 new action schemas: `press`, `fill`, `find`, `check`, `uncheck`, `upload`, `dialog`
- Full test coverage with 64 tests (TDD approach)

## New Action Schemas

| Action | Purpose |
|--------|---------|
| `press` | Keyboard input with modifier support |
| `fill` | Instant form fill (vs keystroke simulation) |
| `find` | Element discovery with scoping and filters |
| `check`/`uncheck` | Idempotent checkbox control |
| `upload` | File upload with path array |
| `dialog` | Pre-registration handlers for alerts/confirms |

## Test Plan

- [x] 64 unit tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.ai/code)