### PR TITLE
feat(core): implement viewport utilities (TDD green)

### DIFF
--- a/packages/core/src/viewport/presets.ts
+++ b/packages/core/src/viewport/presets.ts
@@ -29,12 +29,12 @@ import type {
  * | 2xl  | 1536  |
  */
 export const TAILWIND_BREAKPOINTS: Record<TailwindBreakpoint, number> = {
-	xs: 0,
-	sm: 0,
-	md: 0,
-	lg: 0,
-	xl: 0,
-	'2xl': 0,
+	xs: 375,
+	sm: 640,
+	md: 768,
+	lg: 1024,
+	xl: 1280,
+	'2xl': 1536,
 }
 
 // ============================================================================
@@ -53,7 +53,81 @@ export const TAILWIND_BREAKPOINTS: Record<TailwindBreakpoint, number> = {
  * | laptop    | 1280   | 800    | landscape   | xl       |
  * | desktop   | 1536   | 864    | landscape   | 2xl      |
  */
-export const VIEWPORT_PRESETS: Record<string, ViewportPreset> = {}
+export const VIEWPORT_PRESETS: Record<string, ViewportPreset> = {
+	mobile: {
+		name: 'mobile',
+		width: 375,
+		height: 812,
+		orientation: 'portrait',
+		tailwind: 'xs',
+	},
+	'mobile-xl': {
+		name: 'mobile-xl',
+		width: 430,
+		height: 932,
+		orientation: 'portrait',
+	},
+	tablet: {
+		name: 'tablet',
+		width: 768,
+		height: 1024,
+		orientation: 'portrait',
+		tailwind: 'md',
+	},
+	slate: {
+		name: 'slate',
+		width: 1024,
+		height: 1366,
+		orientation: 'portrait',
+		tailwind: 'lg',
+	},
+	laptop: {
+		name: 'laptop',
+		width: 1280,
+		height: 800,
+		orientation: 'landscape',
+		tailwind: 'xl',
+	},
+	desktop: {
+		name: 'desktop',
+		width: 1536,
+		height: 864,
+		orientation: 'landscape',
+		tailwind: '2xl',
+	},
+}
+
+// ============================================================================
+// Breakpoint Heights
+// ============================================================================
+
+/**
+ * Default heights for Tailwind breakpoints based on typical aspect ratios
+ *
+ * xs, md use portrait orientation (9:16-ish)
+ * sm, lg, xl, 2xl use landscape orientation (16:10-ish)
+ */
+const BREAKPOINT_HEIGHTS: Record<TailwindBreakpoint, number> = {
+	xs: 812,
+	sm: 480,
+	md: 1024,
+	lg: 640,
+	xl: 800,
+	'2xl': 864,
+}
+
+/**
+ * Default orientation for each breakpoint
+ */
+const BREAKPOINT_ORIENTATIONS: Record<TailwindBreakpoint, ViewportOrientation> =
+	{
+		xs: 'portrait',
+		sm: 'landscape',
+		md: 'portrait',
+		lg: 'landscape',
+		xl: 'landscape',
+		'2xl': 'landscape',
+	}
 
 // ============================================================================
 // Helper Functions
@@ -84,5 +158,28 @@ export function getViewportDimensions(
 	name: string,
 	orientation?: ViewportOrientation,
 ): { width: number; height: number } {
-	throw new Error('Not implemented')
+	// Check presets first
+	const preset = VIEWPORT_PRESETS[name]
+	if (preset) {
+		let { width, height } = preset
+		// If orientation specified and differs from default, flip
+		if (orientation && orientation !== preset.orientation) {
+			;[width, height] = [height, width]
+		}
+		return { width, height }
+	}
+
+	// Check breakpoints
+	if (name in TAILWIND_BREAKPOINTS) {
+		const bp = name as TailwindBreakpoint
+		let width = TAILWIND_BREAKPOINTS[bp]
+		let height = BREAKPOINT_HEIGHTS[bp]
+		const defaultOrientation = BREAKPOINT_ORIENTATIONS[bp]
+		if (orientation && orientation !== defaultOrientation) {
+			;[width, height] = [height, width]
+		}
+		return { width, height }
+	}
+
+	throw new Error(`Unknown viewport: ${name}`)
 }

--- a/packages/core/src/viewport/view-parser.ts
+++ b/packages/core/src/viewport/view-parser.ts
@@ -6,7 +6,46 @@
  * @module viewport/view-parser
  */
 
-import type { ResolvedViewport, ViewSpec } from './types'
+import {
+	TAILWIND_BREAKPOINTS,
+	VIEWPORT_PRESETS,
+	getViewportDimensions,
+} from './presets'
+import type {
+	ResolvedViewport,
+	TailwindBreakpoint,
+	ViewSpec,
+	ViewportOrientation,
+	ViewportOrientationWithBoth,
+} from './types'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Valid orientation values for --view flag
+ */
+const VALID_ORIENTATIONS = new Set(['portrait', 'landscape', 'both'])
+
+/**
+ * Shorthand expansions for common viewport sets
+ */
+const VIEW_SHORTHANDS: Record<string, string[]> = {
+	responsive: ['mobile', 'tablet', 'slate', 'laptop', 'desktop'],
+	all: ['mobile', 'mobile-xl', 'tablet', 'slate', 'laptop', 'desktop'],
+}
+
+/**
+ * Validate an orientation value
+ */
+function validateOrientation(orient: string, spec: string): void {
+	if (!VALID_ORIENTATIONS.has(orient)) {
+		throw new Error(
+			`Invalid orientation '${orient}' in '${spec}'. Valid values: portrait, landscape, both`,
+		)
+	}
+}
 
 /**
  * Parse a --view flag value into viewport specifications
@@ -43,7 +82,105 @@ import type { ResolvedViewport, ViewSpec } from './types'
  * ```
  */
 export function parseViewFlag(value: string): ViewSpec[] {
-	throw new Error('Not implemented')
+	if (!value || value.trim() === '') {
+		throw new Error('View flag value cannot be empty')
+	}
+
+	// Handle shorthands with orientation (all:portrait, all:both, responsive:landscape)
+	if (value.startsWith('all:') || value.startsWith('responsive:')) {
+		const parts = value.split(':')
+		const shorthand = parts[0] as string
+		const orient = parts[1] as string
+		const presets = VIEW_SHORTHANDS[shorthand] as string[]
+
+		// Validate orientation
+		validateOrientation(orient, value)
+
+		// For 'both', expand to two entries per preset
+		if (orient === 'both') {
+			return presets.flatMap((p: string) => [
+				{ preset: p, orientation: 'portrait' as ViewportOrientationWithBoth },
+				{ preset: p, orientation: 'landscape' as ViewportOrientationWithBoth },
+			])
+		}
+
+		return presets.map((p: string) => ({
+			preset: p,
+			orientation: orient as ViewportOrientationWithBoth,
+		}))
+	}
+
+	// Handle plain shorthands (responsive, all)
+	if (VIEW_SHORTHANDS[value]) {
+		return VIEW_SHORTHANDS[value].map((p) => ({ preset: p }))
+	}
+
+	// Parse comma-separated specs
+	return value.split(',').map((spec) => parseSpec(spec.trim()))
+}
+
+/**
+ * Parse a single view specification
+ */
+function parseSpec(spec: string): ViewSpec {
+	// Check for orientation modifier (preset:orientation)
+	if (spec.includes(':')) {
+		const parts = spec.split(':')
+		const base = parts[0] as string
+		const orient = parts[1] as string
+
+		// Validate orientation
+		validateOrientation(orient, spec)
+
+		return {
+			preset: base,
+			orientation: orient as ViewportOrientationWithBoth,
+		}
+	}
+
+	// Check if it's a preset
+	if (VIEWPORT_PRESETS[spec]) {
+		return { preset: spec }
+	}
+
+	// Check if it's a breakpoint
+	if (spec in TAILWIND_BREAKPOINTS) {
+		return { breakpoint: spec as TailwindBreakpoint }
+	}
+
+	// Check if explicit dimensions (WxH)
+	if (spec.includes('x')) {
+		const parts = spec.split('x')
+		const wStr = parts[0] as string
+		const hStr = parts[1] as string
+
+		// Validate both parts exist and are non-empty
+		if (!wStr || !hStr) {
+			throw new Error(
+				`Invalid dimensions '${spec}'. Both width and height must be numbers (e.g., 500x800)`,
+			)
+		}
+
+		const w = Number(wStr)
+		const h = Number(hStr)
+
+		// Validate both dimensions are valid numbers
+		if (Number.isNaN(w) || Number.isNaN(h)) {
+			throw new Error(
+				`Invalid dimensions '${spec}'. Both width and height must be numbers (e.g., 500x800)`,
+			)
+		}
+
+		return { width: w, height: h }
+	}
+
+	// Raw width (number only)
+	const width = Number(spec)
+	if (!Number.isNaN(width)) {
+		return { width }
+	}
+
+	throw new Error(`Invalid view spec: ${spec}`)
 }
 
 /**
@@ -70,5 +207,74 @@ export function parseViewFlag(value: string): ViewSpec[] {
  * ```
  */
 export function resolveViewFlag(value: string): ResolvedViewport[] {
-	throw new Error('Not implemented')
+	const specs = parseViewFlag(value)
+	return specs.flatMap((spec) => resolveSpec(spec))
+}
+
+/**
+ * Resolve a single ViewSpec to concrete dimensions
+ */
+function resolveSpec(spec: ViewSpec): ResolvedViewport[] {
+	// Handle 'both' orientation - return two viewports
+	if (spec.orientation === 'both' && spec.preset) {
+		const preset = VIEWPORT_PRESETS[spec.preset]
+		if (!preset) {
+			throw new Error(`Unknown preset: ${spec.preset}`)
+		}
+		const { width, height } = preset
+		return [
+			{
+				name: spec.preset,
+				width,
+				height,
+				orientation: preset.orientation,
+			},
+			{
+				name: spec.preset,
+				width: height,
+				height: width,
+				orientation:
+					preset.orientation === 'portrait' ? 'landscape' : 'portrait',
+			},
+		]
+	}
+
+	// Preset with optional orientation
+	if (spec.preset) {
+		const preset = VIEWPORT_PRESETS[spec.preset]
+		if (!preset) {
+			throw new Error(`Unknown preset: ${spec.preset}`)
+		}
+		const dims = getViewportDimensions(
+			spec.preset,
+			spec.orientation as ViewportOrientation | undefined,
+		)
+		const orientation = spec.orientation ?? preset.orientation
+		return [
+			{
+				name: spec.preset,
+				...dims,
+				orientation: orientation as ViewportOrientation,
+			},
+		]
+	}
+
+	// Breakpoint
+	if (spec.breakpoint) {
+		const dims = getViewportDimensions(spec.breakpoint)
+		return [{ name: spec.breakpoint, ...dims }]
+	}
+
+	// Explicit dimensions (WxH)
+	if (spec.width !== undefined && spec.height !== undefined) {
+		return [{ width: spec.width, height: spec.height }]
+	}
+
+	// Raw width - derive height from default landscape ratio (16:10)
+	if (spec.width !== undefined) {
+		const height = Math.round(spec.width / (16 / 10))
+		return [{ width: spec.width, height }]
+	}
+
+	throw new Error('Cannot resolve view spec')
 }

--- a/packages/core/tests/viewport/presets.test.ts
+++ b/packages/core/tests/viewport/presets.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import {
-	getViewportDimensions,
 	TAILWIND_BREAKPOINTS,
 	VIEWPORT_PRESETS,
+	getViewportDimensions,
 } from '../../src/viewport/presets'
 
 describe('TAILWIND_BREAKPOINTS', () => {

--- a/packages/core/tests/viewport/view-parser.test.ts
+++ b/packages/core/tests/viewport/view-parser.test.ts
@@ -317,3 +317,77 @@ describe('resolveViewFlag', () => {
 		})
 	})
 })
+
+describe('parseViewFlag validation', () => {
+	describe('orientation validation', () => {
+		test('throws for invalid orientation modifier', () => {
+			expect(() => parseViewFlag('mobile:sideways')).toThrow(
+				/Invalid orientation 'sideways'/,
+			)
+		})
+
+		test('throws for invalid orientation on shorthand', () => {
+			expect(() => parseViewFlag('all:invalid')).toThrow(
+				/Invalid orientation 'invalid'/,
+			)
+		})
+
+		test('throws for invalid orientation on responsive shorthand', () => {
+			expect(() => parseViewFlag('responsive:diagonal')).toThrow(
+				/Invalid orientation 'diagonal'/,
+			)
+		})
+
+		test('accepts valid portrait orientation', () => {
+			expect(() => parseViewFlag('mobile:portrait')).not.toThrow()
+		})
+
+		test('accepts valid landscape orientation', () => {
+			expect(() => parseViewFlag('tablet:landscape')).not.toThrow()
+		})
+
+		test('accepts valid both orientation', () => {
+			expect(() => parseViewFlag('desktop:both')).not.toThrow()
+		})
+	})
+
+	describe('dimension validation', () => {
+		test('throws for non-numeric width in WxH', () => {
+			expect(() => parseViewFlag('foox800')).toThrow(
+				/Invalid dimensions 'foox800'/,
+			)
+		})
+
+		test('throws for non-numeric height in WxH', () => {
+			expect(() => parseViewFlag('500xbar')).toThrow(
+				/Invalid dimensions '500xbar'/,
+			)
+		})
+
+		test('throws for partial WxH (missing height)', () => {
+			expect(() => parseViewFlag('500x')).toThrow(/Invalid dimensions '500x'/)
+		})
+
+		test('throws for partial WxH (missing width)', () => {
+			expect(() => parseViewFlag('x800')).toThrow(/Invalid dimensions 'x800'/)
+		})
+
+		test('accepts valid WxH dimensions', () => {
+			expect(() => parseViewFlag('500x800')).not.toThrow()
+		})
+
+		test('accepts valid large dimensions', () => {
+			expect(() => parseViewFlag('1920x1080')).not.toThrow()
+		})
+	})
+
+	describe('empty value validation', () => {
+		test('throws for empty string', () => {
+			expect(() => parseViewFlag('')).toThrow(/cannot be empty/)
+		})
+
+		test('throws for whitespace-only string', () => {
+			expect(() => parseViewFlag('   ')).toThrow(/cannot be empty/)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

TDD green phase: Implement viewport utilities to pass all 82 tests.

## Implementation

### Constants

```typescript
TAILWIND_BREAKPOINTS = { xs: 375, sm: 640, md: 768, lg: 1024, xl: 1280, '2xl': 1536 }

VIEWPORT_PRESETS = {
  mobile:    { width: 375,  height: 812,  orientation: 'portrait',  tailwind: 'xs' },
  'mobile-xl': { width: 430,  height: 932,  orientation: 'portrait' },
  tablet:    { width: 768,  height: 1024, orientation: 'portrait',  tailwind: 'md' },
  slate:     { width: 1024, height: 1366, orientation: 'portrait',  tailwind: 'lg' },
  laptop:    { width: 1280, height: 800,  orientation: 'landscape', tailwind: 'xl' },
  desktop:   { width: 1536, height: 864,  orientation: 'landscape', tailwind: '2xl' },
}
```

### Functions

| Function | Purpose |
|----------|---------|
| `getViewportDimensions(name, orientation?)` | Resolve preset/breakpoint to `{width, height}` |
| `parseViewFlag(value)` | Parse `--view` syntax to `ViewSpec[]` |
| `resolveViewFlag(value)` | Fully resolve to `ResolvedViewport[]` |

### `--view` Syntax Support

- Presets: `mobile`, `tablet`, `laptop`, etc.
- Orientation: `mobile:landscape`, `tablet:portrait`, `tablet:both`
- Breakpoints: `xs`, `sm`, `md`, `lg`, `xl`, `2xl`
- Dimensions: `500x800`, `1920x1080`
- Raw width: `500` (derives height from 16:10)
- Shorthands: `responsive` (5), `all` (6), `all:both` (12)

## Test Results

```
82 pass
0 fail
98 expect() calls
```

## Test Plan

- [x] All 82 tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>