### PR TITLE
feat: wire --view flag to CLI snap/screenshot commands

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,3 +67,6 @@ export {
 	type ColorSchemeInput,
 	type ColorSchemeOutput,
 } from './utils'
+
+// Viewport utilities
+export * from './viewport'

--- a/packages/core/src/schema/action.ts
+++ b/packages/core/src/schema/action.ts
@@ -216,6 +216,7 @@ const screenshotAction = z.object({
 	selector: z.string().optional(),
 	fullPage: z.boolean().optional(),
 	quality: z.number().optional(),
+	view: z.string().optional(),
 })
 
 // 'snap' instead of 'snapshot'
@@ -228,6 +229,7 @@ const snapAction = z.object({
 	depth: z.number().optional(),
 	selector: z.string().optional(),
 	visibleOnly: z.boolean().optional(),
+	view: z.string().optional(),
 })
 
 const htmlAction = z.object({
@@ -429,6 +431,7 @@ export type CheckAction = z.infer<typeof checkAction>
 export type UncheckAction = z.infer<typeof uncheckAction>
 export type UploadAction = z.infer<typeof uploadAction>
 export type DialogAction = z.infer<typeof dialogAction>
+export type ScreenshotAction = z.infer<typeof screenshotAction>
 
 // Browser mode type (uses 'paired' instead of 'guided')
 export type BrowserMode = 'headless' | 'windowed' | 'paired'

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -15,6 +15,7 @@ export {
 	type ModeAction,
 	type NavigateAction,
 	type PressAction,
+	type ScreenshotAction,
 	type SnapAction,
 	type TabRef,
 	type TypeAction,

--- a/packages/server/src/actions/executor.ts
+++ b/packages/server/src/actions/executor.ts
@@ -17,7 +17,7 @@ import type {
 	TabRef,
 	Viewport,
 } from '@outfitter/navigator-core'
-import { parseKeyCombo } from '@outfitter/navigator-core'
+import { parseKeyCombo, resolveViewFlag } from '@outfitter/navigator-core'
 import type { BrowserManager } from '../browser/manager'
 import { MarkerStore, markersToMarkdown } from '../markers'
 import type { PairedManager } from '../paired/manager'
@@ -245,6 +245,9 @@ export class ActionExecutor {
 
 			// Capture
 			case 'screenshot':
+				if (action.view) {
+					return this.screenshotMultiViewport(action)
+				}
 				return this.screenshot(
 					action.tab,
 					action.ref,
@@ -253,6 +256,9 @@ export class ActionExecutor {
 					action.quality,
 				)
 			case 'snap':
+				if (action.view) {
+					return this.snapMultiViewport(action)
+				}
 				return this.snap(action.tab, action.mode, action)
 			case 'html':
 				return this.getHtml(action.tab, action.ref, action.selector)
@@ -1094,6 +1100,228 @@ export class ActionExecutor {
 				mode: mode ?? 'full',
 				interactiveCount: Object.keys(refs).length,
 			},
+		}
+	}
+
+	/**
+	 * Get the current viewport dimensions.
+	 */
+	private async getCurrentViewport(
+		tab?: TabRef,
+	): Promise<{ width: number; height: number } | null> {
+		const response = await this.withTab(tab, async () =>
+			this.browserManager.send<{ width: number; height: number }>({
+				action: 'evaluate',
+				script:
+					'() => ({ width: window.innerWidth, height: window.innerHeight })',
+			}),
+		)
+
+		if (response.success && response.data) {
+			// Handle evaluate result which wraps in { result: ... }
+			const data = response.data as unknown as {
+				result?: { width: number; height: number }
+			}
+			if (data.result) {
+				return data.result
+			}
+		}
+		return null
+	}
+
+	/**
+	 * Set viewport and return success status.
+	 */
+	private async setViewportDimensions(
+		tab: TabRef | undefined,
+		width: number,
+		height: number,
+	): Promise<boolean> {
+		const response = await this.withTab(tab, async () =>
+			this.browserManager.send({
+				action: 'viewport',
+				width,
+				height,
+			}),
+		)
+		return response.success
+	}
+
+	/**
+	 * Screenshot at multiple viewports.
+	 */
+	private async screenshotMultiViewport(action: {
+		tab?: TabRef | undefined
+		ref?: string | undefined
+		selector?: string | undefined
+		fullPage?: boolean | undefined
+		quality?: number | undefined
+		view?: string | undefined
+	}): Promise<ActionResult> {
+		if (!action.view) {
+			return { success: false, error: 'view parameter is required' }
+		}
+		const viewports = resolveViewFlag(action.view)
+		const screenshots: Array<{ viewport: string; data: string }> = []
+
+		// Save original viewport
+		const originalViewport = await this.getCurrentViewport(action.tab)
+
+		try {
+			for (const vp of viewports) {
+				// Set viewport
+				const success = await this.setViewportDimensions(
+					action.tab,
+					vp.width,
+					vp.height,
+				)
+				if (!success) {
+					return {
+						success: false,
+						error: `Failed to set viewport to ${vp.width}x${vp.height}`,
+					}
+				}
+
+				// Small delay to let layout settle
+				await new Promise((resolve) => setTimeout(resolve, 100))
+
+				// Capture screenshot at this viewport
+				const result = await this.screenshot(
+					action.tab,
+					action.ref,
+					action.selector,
+					action.fullPage,
+					action.quality,
+				)
+
+				if (!result.success || !result.screenshot) {
+					return {
+						success: false,
+						error:
+							result.error ??
+							`Screenshot failed at viewport ${vp.name ?? `${vp.width}x${vp.height}`}`,
+					}
+				}
+
+				screenshots.push({
+					viewport: vp.name ?? `${vp.width}x${vp.height}`,
+					data: result.screenshot,
+				})
+			}
+
+			return { success: true, data: { screenshots } }
+		} finally {
+			// Restore original viewport
+			if (originalViewport) {
+				await this.setViewportDimensions(
+					action.tab,
+					originalViewport.width,
+					originalViewport.height,
+				)
+			}
+		}
+	}
+
+	/**
+	 * Snap at multiple viewports.
+	 */
+	private async snapMultiViewport(action: {
+		tab?: TabRef | undefined
+		mode?: 'full' | 'interactive' | 'input_fields' | 'text_only' | undefined
+		interactive?: boolean | undefined
+		compact?: boolean | undefined
+		depth?: number | undefined
+		selector?: string | undefined
+		visibleOnly?: boolean | undefined
+		view?: string | undefined
+	}): Promise<ActionResult> {
+		if (this.isPairedActive()) {
+			return {
+				success: false,
+				error:
+					'snap is not available in paired mode. Use marker/html/text instead.',
+			}
+		}
+
+		if (!action.view) {
+			return { success: false, error: 'view parameter is required' }
+		}
+
+		const viewports = resolveViewFlag(action.view)
+		const snaps: Array<{
+			viewport: string
+			result: {
+				tree?: string | undefined
+				version?: number | undefined
+				url?: string | undefined
+				title?: string | undefined
+				mode?: string | undefined
+				interactiveCount?: number | undefined
+			}
+		}> = []
+
+		// Save original viewport
+		const originalViewport = await this.getCurrentViewport(action.tab)
+
+		try {
+			for (const vp of viewports) {
+				// Set viewport
+				const success = await this.setViewportDimensions(
+					action.tab,
+					vp.width,
+					vp.height,
+				)
+				if (!success) {
+					return {
+						success: false,
+						error: `Failed to set viewport to ${vp.width}x${vp.height}`,
+					}
+				}
+
+				// Small delay to let layout settle
+				await new Promise((resolve) => setTimeout(resolve, 100))
+
+				// Capture snap at this viewport
+				const result = await this.snap(action.tab, action.mode, {
+					interactive: action.interactive,
+					compact: action.compact,
+					depth: action.depth,
+					selector: action.selector,
+					visibleOnly: action.visibleOnly,
+				})
+
+				if (!result.success) {
+					return {
+						success: false,
+						error:
+							result.error ??
+							`Snap failed at viewport ${vp.name ?? `${vp.width}x${vp.height}`}`,
+					}
+				}
+
+				snaps.push({
+					viewport: vp.name ?? `${vp.width}x${vp.height}`,
+					result: {
+						tree: result.snapshot?.tree,
+						version: result.snapshot?.version,
+						url: result.snapshot?.url,
+						title: result.snapshot?.title,
+						mode: result.snapshot?.mode,
+						interactiveCount: result.snapshot?.interactiveCount,
+					},
+				})
+			}
+
+			return { success: true, data: { snaps } }
+		} finally {
+			// Restore original viewport
+			if (originalViewport) {
+				await this.setViewportDimensions(
+					action.tab,
+					originalViewport.width,
+					originalViewport.height,
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Wire the `--view` flag to CLI and server, enabling multi-viewport capture for snap and screenshot commands.

## CLI Commands

```bash
# Single viewport
nav snap --view mobile
nav screenshot output --view tablet

# Multiple viewports
nav snap --view mobile,tablet,laptop
nav screenshot output --view mobile,desktop

# Shorthands
nav snap --view responsive      # 5 core viewports
nav screenshot output --view all # 6 viewports → output-mobile.png, output-tablet.png, etc.
```

## Changes

### Schema (`packages/core/src/schema/action.ts`)
- Added `view: z.string().optional()` to `snapAction`
- Added `view: z.string().optional()` to `screenshotAction`

### CLI (`packages/cli/src/commands/interaction.ts`)
- Added `--view <viewports>` option to `snap` command
- Added `--view <viewports>` option to `screenshot` command
- Multi-viewport screenshots save as `{name}-{viewport}.png`

### Server (`packages/server/src/actions/executor.ts`)
- `screenshotMultiViewport()` - captures at each viewport, restores original
- `snapMultiViewport()` - same pattern for snap action
- `getCurrentViewport()` / `setViewportDimensions()` helpers

## Response Format

**Single viewport** (existing):
```json
{ "success": true, "data": { "tree": "...", "elements": [...] } }
```

**Multi-viewport** (new):
```json
{
  "success": true,
  "data": {
    "snaps": [
      { "viewport": "mobile", "result": { "tree": "...", "elements": [...] } },
      { "viewport": "tablet", "result": { "tree": "...", "elements": [...] } }
    ]
  }
}
```

## Test Plan

- [x] 268 tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] Manual: `nav snap --view mobile` works

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>