### PR TITLE
refactor(cli): reduce cognitive complexity in display and interaction commands

### DIFF
--- a/packages/cli/src/commands/display.ts
+++ b/packages/cli/src/commands/display.ts
@@ -19,6 +19,51 @@ const VIEWPORT_PRESETS = {
 } as const
 
 type ViewportPreset = keyof typeof VIEWPORT_PRESETS
+type ViewportDimensions = { width: number; height: number }
+
+/** Format error message from unknown error */
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error)
+}
+
+/** Resolve viewport dimensions from preset name */
+function resolvePreset(
+	presetName: string,
+):
+	| { ok: true; dimensions: ViewportDimensions; name: ViewportPreset }
+	| { ok: false; error: string } {
+	if (!(presetName in VIEWPORT_PRESETS)) {
+		return {
+			ok: false,
+			error: `Invalid preset: ${presetName}. Use: mobile, tablet, desktop`,
+		}
+	}
+	const name = presetName as ViewportPreset
+	return { ok: true, dimensions: VIEWPORT_PRESETS[name], name }
+}
+
+/** Parse and validate explicit dimensions */
+function parseDimensions(
+	widthStr?: string,
+	heightStr?: string,
+): { ok: true; dimensions: ViewportDimensions } | { ok: false; error: string } {
+	if (!widthStr || !heightStr) {
+		return {
+			ok: false,
+			error:
+				'Usage: nav viewport <width> <height> or nav viewport --preset <name>',
+		}
+	}
+
+	const width = Number(widthStr)
+	const height = Number(heightStr)
+
+	if (Number.isNaN(width) || Number.isNaN(height)) {
+		return { ok: false, error: 'Width and height must be valid numbers' }
+	}
+
+	return { ok: true, dimensions: { width, height } }
+}
 
 export function registerDisplayCommands(
 	program: Command,
@@ -37,65 +82,28 @@ export function registerDisplayCommands(
 			) => {
 				const client = getClient()
 
-				// Handle preset
-				if (options?.preset) {
-					const presetName = options.preset as ViewportPreset
-					if (!(presetName in VIEWPORT_PRESETS)) {
-						console.error(
-							`Invalid preset: ${options.preset}. Use: mobile, tablet, desktop`,
-						)
-						process.exitCode = 1
-						return
-					}
+				// Resolve dimensions from preset or explicit args
+				const resolved = options?.preset
+					? resolvePreset(options.preset)
+					: parseDimensions(widthStr, heightStr)
 
-					const preset = VIEWPORT_PRESETS[presetName]
-					try {
-						await client.execute({
-							action: 'viewport',
-							width: preset.width,
-							height: preset.height,
-						})
-						console.log(
-							`Viewport set to ${presetName}: ${preset.width}x${preset.height}`,
-						)
-					} catch (error) {
-						console.error(
-							`Failed to set viewport: ${error instanceof Error ? error.message : String(error)}`,
-						)
-						process.exitCode = 1
-					}
-					return
-				}
-
-				// Handle explicit dimensions
-				if (!widthStr || !heightStr) {
-					console.error(
-						'Usage: nav viewport <width> <height> or nav viewport --preset <name>',
-					)
+				if (!resolved.ok) {
+					console.error(resolved.error)
 					process.exitCode = 1
 					return
 				}
 
-				const width = Number(widthStr)
-				const height = Number(heightStr)
-
-				if (Number.isNaN(width) || Number.isNaN(height)) {
-					console.error('Width and height must be valid numbers')
-					process.exitCode = 1
-					return
-				}
+				const { width, height } = resolved.dimensions
+				const label =
+					'name' in resolved
+						? `${resolved.name}: ${width}x${height}`
+						: `${width}x${height}`
 
 				try {
-					await client.execute({
-						action: 'viewport',
-						width,
-						height,
-					})
-					console.log(`Viewport set to: ${width}x${height}`)
+					await client.execute({ action: 'viewport', width, height })
+					console.log(`Viewport set to ${label}`)
 				} catch (error) {
-					console.error(
-						`Failed to set viewport: ${error instanceof Error ? error.message : String(error)}`,
-					)
+					console.error(`Failed to set viewport: ${formatError(error)}`)
 					process.exitCode = 1
 				}
 			},

--- a/packages/cli/src/commands/interaction.ts
+++ b/packages/cli/src/commands/interaction.ts
@@ -13,6 +13,36 @@ import type { NavigatorClient } from '../client.js'
 /** Matches element refs like e42 or e42_1 or @e42 */
 const ELEMENT_REF_REGEX = /^@?e\d+(?:_\d+)?$/
 
+/** Snap result with optional multi-viewport data */
+interface SnapResult {
+	tree?: string
+	elements?: unknown
+	snaps?: Array<{ viewport: string; result: { tree?: string } }>
+	data?: {
+		snaps?: Array<{ viewport: string; result: { tree?: string } }>
+	}
+}
+
+/**
+ * Output snap result to console, handling multi-viewport and single results.
+ */
+function outputSnapResult(result: SnapResult): void {
+	const snaps = result.data?.snaps ?? result.snaps
+	if (snaps && snaps.length > 0) {
+		for (const { viewport, result: snapResult } of snaps) {
+			console.log(`\n=== Viewport: ${viewport} ===\n`)
+			const output = snapResult.tree ?? JSON.stringify(snapResult, null, 2)
+			console.log(output)
+		}
+		return
+	}
+	if (result.tree) {
+		console.log(result.tree)
+		return
+	}
+	console.log(JSON.stringify(result, null, 2))
+}
+
 /** Options for the find command */
 interface FindOptions {
 	role?: string
@@ -88,14 +118,7 @@ export function registerInteractionCommands(
 		)
 		.action(async (options) => {
 			const client = getClient()
-			const result = await client.execute<{
-				tree?: string
-				elements?: unknown
-				snaps?: Array<{ viewport: string; result: { tree?: string } }>
-				data?: {
-					snaps?: Array<{ viewport: string; result: { tree?: string } }>
-				}
-			}>({
+			const result = await client.execute<SnapResult>({
 				action: 'snap',
 				interactive: options.interactive,
 				visibleOnly: options.visible,
@@ -104,23 +127,7 @@ export function registerInteractionCommands(
 				selector: options.selector,
 				view: options.view,
 			})
-
-			// Handle multi-viewport result (server returns data under result.data)
-			const snaps = result.data?.snaps ?? result.snaps
-			if (snaps && snaps.length > 0) {
-				for (const { viewport, result: snapResult } of snaps) {
-					console.log(`\n=== Viewport: ${viewport} ===\n`)
-					if (snapResult.tree) {
-						console.log(snapResult.tree)
-					} else {
-						console.log(JSON.stringify(snapResult, null, 2))
-					}
-				}
-			} else if (result.tree) {
-				console.log(result.tree)
-			} else {
-				console.log(JSON.stringify(result, null, 2))
-			}
+			outputSnapResult(result)
 		})
 
 	// nav click <ref|selector>


### PR DESCRIPTION
## Summary

Reduces cognitive complexity in CLI command handlers to satisfy Biome's complexity limit of 15. This refactor extracts helper functions and uses early returns to flatten deeply nested conditionals.

## Changes

**packages/cli/src/commands/display.ts**
- Extract `resolvePreset()` to handle viewport preset resolution
- Extract `parseDimensions()` to parse width/height strings
- Extract `formatError()` for consistent error formatting
- Use early returns to reduce nesting depth

**packages/cli/src/commands/interaction.ts**
- Extract `outputSnapResult()` helper for snap output formatting
- Apply Result-like patterns to flatten conditional logic

## Why

Biome's cognitive complexity rule flagged these files. Rather than suppressing the warnings, this refactor improves readability by breaking down complex functions into focused helpers.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Manual testing of affected commands (`nav viewport`, `nav snap`, `nav click`)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>