### PR TITLE
refactor(server): replace hono/logger with @logtape/hono

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
       "name": "@outfitter/navigator-core",
       "version": "0.1.0",
       "dependencies": {
-        "@logtape/logtape": "^0.10.0",
+        "@logtape/logtape": "^2.0.0",
         "yaml": "^2.6.1",
         "zod": "^3.24.1",
       },
@@ -86,6 +86,7 @@
       "name": "@outfitter/navigator-server",
       "version": "0.1.0",
       "dependencies": {
+        "@logtape/hono": "^2.0.0",
         "@outfitter/agent-browser": "github:outfitter-dev/agent-browser",
         "@outfitter/navigator-core": "workspace:*",
         "hono": "^4.7.1",
@@ -226,7 +227,9 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@logtape/logtape": ["@logtape/logtape@0.10.0", "", {}, "sha512-zk8YILUU7TACEDPaI7sPO6Jyxj6+gwXeS82/ANAtIs3oyLqbUp1kzi5RWUjRj7yu8R7Hd0C4cX4fmfOo9S7COA=="],
+    "@logtape/hono": ["@logtape/hono@2.0.0", "", { "peerDependencies": { "@logtape/logtape": "^2.0.0", "hono": "^4.0.0" } }, "sha512-aP/Siqat5Plo27f49xPRaZqtIjYlqlQUtXs3LqzHr4DeBAWxycdVAz9DEkUqRKU7ZsmJvB7VhoQTLjPfPnq0eQ=="],
+
+    "@logtape/logtape": ["@logtape/logtape@2.0.0", "", {}, "sha512-z9Hp44mIRXAzgxSyQfFQiRuJ78EMnZa6g43UCxyGOO3RgHjn/7q+5OhdbhypkeHjiJRPxv6RmRsyF0S+OOYWnA=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
 		"test": "bun test"
 	},
 	"dependencies": {
-		"@logtape/logtape": "^0.10.0",
+		"@logtape/logtape": "^2.0.0",
 		"yaml": "^2.6.1",
 		"zod": "^3.24.1"
 	},

--- a/packages/core/src/logging/sinks.ts
+++ b/packages/core/src/logging/sinks.ts
@@ -123,6 +123,7 @@ export function createDevConsoleSink(): Sink {
 		levelStyle: 'bold',
 		categoryStyle: 'dim',
 		levelColors: {
+			trace: null,
 			debug: 'cyan',
 			info: 'green',
 			warning: 'yellow',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
 		"test": "bun test"
 	},
 	"dependencies": {
+		"@logtape/hono": "^2.0.0",
 		"@outfitter/agent-browser": "github:outfitter-dev/agent-browser",
 		"@outfitter/navigator-core": "workspace:*",
 		"hono": "^4.7.1",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,7 @@
  * @module navigator-server
  */
 
+import { honoLogger } from '@logtape/hono'
 import {
 	type Action,
 	type ActionResult,
@@ -20,7 +21,6 @@ import {
 } from '@outfitter/navigator-core/logging'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
-import { logger } from 'hono/logger'
 import { ActionExecutor } from './actions/executor'
 import { BrowserManager } from './browser/manager'
 import { PairedManager } from './paired/manager'
@@ -85,7 +85,7 @@ const app = new Hono()
 
 // Middleware
 app.use('*', cors())
-app.use('*', logger())
+app.use('*', honoLogger())
 
 // Health check
 app.get('/health', (c) => {


### PR DESCRIPTION
## Summary

Swaps HTTP request logging middleware from `hono/logger` to `@logtape/hono` for unified logging through the LogTape infrastructure.

## Changes

- Add `@logtape/hono@2.0.0` dependency to server
- Upgrade `@logtape/logtape` from `^0.10.0` to `^2.0.0` in core
- Add `trace` level color to sinks.ts (v2 compatibility)
- Replace `logger()` middleware with `honoLogger()`

## Why

- **Unified logging** - HTTP requests logged through same infrastructure as app logs
- **Consistent format** - Same timestamp, category, level styling
- **Filterable** - Uses `['hono']` category for easy filtering

## Example Output

```
13:45:23.100 [INF] hono: GET /action 200 12ms
13:45:23.200 [INF] hono: POST /action 200 45ms
```

## Test Plan

- [x] All tests pass
- [x] TypeScript strict mode passes
- [x] Biome lint passes

---

🤖 Generated with [Claude Code](https://claude.ai/code)