### PR TITLE
feat(cli): add --debug flag for verbose logging

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -5,8 +5,11 @@
  */
 
 import { loadConfig } from '@outfitter/navigator-core/config'
+import { CATEGORIES, getLogger } from '@outfitter/navigator-core/logging'
 import { detectProjectRoot } from '@outfitter/navigator-core/project'
 import { type Action, ActionSchema } from '@outfitter/navigator-core/schema'
+
+const logger = getLogger(CATEGORIES.CLI_COMMANDS)
 
 // ============================================================================
 // Types
@@ -42,6 +45,8 @@ export function createClient(options: ClientOptions = {}): NavigatorClient {
 	const serverUrl = `http://localhost:${port}`
 	const projectPath = options.project ?? detectProjectRoot() ?? process.cwd()
 
+	logger.debug`Creating client: server=${serverUrl} project=${projectPath}`
+
 	return {
 		serverUrl,
 		projectPath,
@@ -49,6 +54,7 @@ export function createClient(options: ClientOptions = {}): NavigatorClient {
 		async execute<T = unknown>(action: Action): Promise<T> {
 			// Validate action before sending
 			const validated = ActionSchema.parse(action)
+			logger.debug`Executing action: ${validated.action}`
 
 			const response = await fetch(`${serverUrl}/action`, {
 				method: 'POST',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,11 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import {
+	CATEGORIES,
+	configureLogging,
+	getLogger,
+} from '@outfitter/navigator-core/logging'
 import { Command } from 'commander'
 import { type ClientOptions, createClient } from './client.js'
 import { registerDisplayCommands } from './commands/display.js'
@@ -58,6 +63,7 @@ program
 	.option('-s, --session <id>', 'Use specific session')
 	.option('-p, --project <path>', 'Project root path')
 	.option('--port <number>', 'Server port (default: 9334)')
+	.option('-d, --debug', 'Enable verbose debug logging')
 
 // ============================================================================
 // Client Factory
@@ -234,11 +240,37 @@ program
 	})
 
 // ============================================================================
+// Logging Setup
+// ============================================================================
+
+/**
+ * Initialize logging if --debug flag is set.
+ * Called before each command via preAction hook.
+ */
+let loggingInitialized = false
+async function initializeLogging(): Promise<void> {
+	if (loggingInitialized) return
+
+	const opts = program.opts<{ debug?: boolean }>()
+	if (opts.debug) {
+		await configureLogging({
+			environment: 'development',
+			level: 'debug',
+		})
+		const logger = getLogger(CATEGORIES.CLI)
+		logger.debug`CLI debug logging enabled`
+	}
+	loggingInitialized = true
+}
+
+// ============================================================================
 // Error Handling
 // ============================================================================
 
-program.hook('preAction', () => {
-	// Set up error handler for async actions
+program.hook('preAction', async (_thisCommand, actionCommand) => {
+	// Skip CLI logging for mcp command - it configures its own logging
+	if (actionCommand.name() === 'mcp') return
+	await initializeLogging()
 })
 
 // Handle errors from async actions


### PR DESCRIPTION
## Summary

Adds a global `--debug` (`-d`) flag to enable verbose LogTape logging for CLI internals. By default, the CLI is silent - only user-facing command output is shown.

## Changes

- Add `-d, --debug` global flag to CLI
- Conditionally configure LogTape in `preAction` hook
- Add debug logging for client creation and action execution

## Behavior

| Mode | Logging |
|------|---------|
| Normal | Silent - only command output via console.log |
| `--debug` | Verbose - LogTape debug logs for internals |

## Usage

```bash
# Normal usage (quiet)
nav open https://example.com
nav snap

# Debug mode (verbose)
nav --debug open https://example.com
nav -d snap
```

## Example Debug Output

```
13:45:23.100 [DBG] navigator.cli: Creating client: server=http://localhost:9334 project=/path/to/project
13:45:23.150 [DBG] navigator.cli: Executing action: navigate
```

## Test Plan

- [x] TypeScript strict mode passes
- [x] Biome lint passes
- [x] Manual testing: `--debug` shows logs, without flag is silent

---

🤖 Generated with [Claude Code](https://claude.ai/code)