### PR TITLE
docs: remove undocumented symbol prefix references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,12 +73,6 @@ Navigator supports session continuity with auto-continuation:
 
 Element refs use format `e{index}_{version}` (e.g., `e42_1`). Shorthand `e42` implies current snap.
 
-Symbol prefixes indicate element type:
-- `#` = text-insertable (input, textarea)
-- `@` = link
-- `$` = clickable
-- `%` = image
-
 **Workflow note**: Refs point to DOM elements by index. After page-changing actions (click, navigate), DOM may change - take a fresh snap if refs fail. Use shorthand (`e1`) to skip version validation.
 
 ### Action Categories

--- a/packages/mcp/src/description.ts
+++ b/packages/mcp/src/description.ts
@@ -12,17 +12,12 @@ import { ACTION_CATEGORIES } from './schema'
  *
  * Design principles:
  * - Single tool reduces context overhead vs 26+ separate tools
- * - Symbol prefixes (#, @, $, %) communicate element types
  * - Snap → interact → snap workflow pattern
  */
 export function generateToolDescription(): string {
 	return `Browser automation for AI agents. Execute actions on web pages.
 
-**Element References**: Use refs from \`snap\` output (e.g., "e42"). Symbols indicate type:
-- #ref = text input (type action)
-- @ref = link (click to navigate)
-- $ref = button/interactive (click)
-- %ref = image
+**Element References**: Use refs from \`snap\` output (e.g., "e42").
 
 **Actions**:
 ${formatActionCategories()}


### PR DESCRIPTION
## Summary

Remove references to symbol prefixes (`#`, `@`, `$`, `%`) from documentation. These were documented as element type indicators but were never implemented in agent-browser.

## Changes

- **CLAUDE.md**: Removed symbol prefix section from Element Reference System docs
- **packages/mcp/src/description.ts**: Removed symbol references from design principles and tool description

## Rationale

Don't document what isn't implemented. If we want symbols in the future, we should implement them first, then document.

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Documentation accurately reflects implementation

---

🤖 Generated with [Claude Code](https://claude.ai/code)