### PR TITLE
feat(extension): add visual indicator for agent control

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -156,6 +156,16 @@ function handleServerMessage(message: ServerMessage): void {
 			}
 			break
 		}
+
+		case 'action:start':
+			// Agent started executing an action - show halo
+			notifyContentScripts({ type: 'navigator:agentActionStart' })
+			break
+
+		case 'action:end':
+			// Agent finished executing an action - hide halo
+			notifyContentScripts({ type: 'navigator:agentActionEnd' })
+			break
 	}
 }
 

--- a/packages/extension/src/content/index.ts
+++ b/packages/extension/src/content/index.ts
@@ -12,6 +12,8 @@ let userActionListenersActive = false
 let startPoint: { x: number; y: number } | null = null
 let overlay: HTMLDivElement | null = null
 let modeIndicator: HTMLDivElement | null = null
+let agentControlActive = false
+let agentHalo: HTMLDivElement | null = null
 
 // Geometry types
 interface PointGeometry {
@@ -142,6 +144,9 @@ function handleUserClick(event: MouseEvent): void {
 	if (target?.hasAttribute?.('data-navigator-overlay')) return
 	if (markerMode) return
 
+	// User took control - hide agent halo
+	hideAgentHalo()
+
 	const selector = target ? getSelector(target) : undefined
 	sendUserActionEvent({
 		type: 'userAction',
@@ -159,6 +164,9 @@ function handleUserInput(event: Event): void {
 	const target = event.target as HTMLElement
 	if (!target) return
 
+	// User took control - hide agent halo
+	hideAgentHalo()
+
 	const selector = getSelector(target)
 	sendUserActionEvent({
 		type: 'userAction',
@@ -174,6 +182,10 @@ function handleUserInput(event: Event): void {
 let scrollTimeout: ReturnType<typeof setTimeout> | null = null
 function handleUserScroll(event: Event): void {
 	if (!event.isTrusted) return
+
+	// User took control - hide agent halo immediately (no debounce)
+	hideAgentHalo()
+
 	if (scrollTimeout) return
 	scrollTimeout = setTimeout(() => {
 		sendUserActionEvent({
@@ -352,6 +364,34 @@ function showModeIndicator(): void {
 function hideModeIndicator(): void {
 	modeIndicator?.remove()
 	modeIndicator = null
+}
+
+// ============================================================================
+// Agent Control Halo (for paired mode)
+// ============================================================================
+
+/**
+ * Show agent control halo - indicates agent is executing an action
+ */
+function showAgentHalo(): void {
+	if (agentHalo) return
+
+	agentControlActive = true
+	agentHalo = document.createElement('div')
+	agentHalo.setAttribute('data-navigator-overlay', 'agent-control')
+	agentHalo.className = 'navigator-agent-control'
+	document.body.appendChild(agentHalo)
+}
+
+/**
+ * Hide agent control halo - agent action completed or user took control
+ */
+function hideAgentHalo(): void {
+	if (!agentHalo) return
+
+	agentControlActive = false
+	agentHalo.remove()
+	agentHalo = null
 }
 
 /**
@@ -720,6 +760,7 @@ chrome.runtime.onMessage.addListener(
 
 			case 'navigator:disablePairedMode':
 				disableUserActionListeners()
+				hideAgentHalo() // Clear any active halo on disable
 				sendResponse({ success: true })
 				break
 
@@ -728,7 +769,18 @@ chrome.runtime.onMessage.addListener(
 					enableUserActionListeners()
 				} else {
 					disableUserActionListeners()
+					hideAgentHalo() // Clear any active halo when paired mode is off
 				}
+				sendResponse({ success: true })
+				break
+
+			case 'navigator:agentActionStart':
+				showAgentHalo()
+				sendResponse({ success: true })
+				break
+
+			case 'navigator:agentActionEnd':
+				hideAgentHalo()
 				sendResponse({ success: true })
 				break
 		}

--- a/packages/extension/src/content/styles.css
+++ b/packages/extension/src/content/styles.css
@@ -45,6 +45,20 @@
 	animation: navigator-pulse 2s ease-in-out infinite;
 }
 
+/* Agent control indicator - shows when agent is executing an action */
+.navigator-agent-control {
+	position: fixed;
+	inset: 0;
+	border: 4px solid rgba(251, 146, 60, 0.8);
+	border-radius: 0;
+	pointer-events: none;
+	z-index: 2147483647;
+	box-shadow:
+		inset 0 0 20px rgba(251, 146, 60, 0.3),
+		0 0 30px rgba(251, 146, 60, 0.4);
+	animation: navigator-agent-pulse 1.5s ease-in-out infinite;
+}
+
 /* Animations */
 @keyframes navigator-fade-in {
 	from {
@@ -64,6 +78,22 @@
 	}
 	50% {
 		box-shadow: 0 0 0 4px rgba(16, 185, 129, 0);
+	}
+}
+
+@keyframes navigator-agent-pulse {
+	0%,
+	100% {
+		border-color: rgba(251, 146, 60, 0.8);
+		box-shadow:
+			inset 0 0 20px rgba(251, 146, 60, 0.3),
+			0 0 30px rgba(251, 146, 60, 0.4);
+	}
+	50% {
+		border-color: rgba(251, 146, 60, 0.5);
+		box-shadow:
+			inset 0 0 30px rgba(251, 146, 60, 0.5),
+			0 0 50px rgba(251, 146, 60, 0.6);
 	}
 }
 

--- a/packages/server/src/actions/executor.ts
+++ b/packages/server/src/actions/executor.ts
@@ -95,6 +95,11 @@ export class ActionExecutor {
 
 		log.debug`Action received ${{ action: action.action, target }}`
 
+		// Notify extension of agent action start (for visual indicator)
+		if (this.isPairedActive()) {
+			this.pairedManager.broadcastActionStart()
+		}
+
 		// Broadcast action start
 		this.broadcastEvent({
 			ts: new Date().toISOString(),
@@ -120,6 +125,11 @@ export class ActionExecutor {
 		}
 
 		const duration = Date.now() - start
+
+		// Notify extension of agent action end (to hide visual indicator)
+		if (this.isPairedActive()) {
+			this.pairedManager.broadcastActionEnd()
+		}
 
 		if (result.success) {
 			log.debug`Action completed ${{ action: action.action, duration }}`

--- a/packages/server/src/paired/manager.ts
+++ b/packages/server/src/paired/manager.ts
@@ -121,6 +121,34 @@ export class PairedManager {
 	}
 
 	/**
+	 * Broadcast an agent action start event to all connected extensions.
+	 * Used to show the agent control halo in the extension.
+	 */
+	broadcastActionStart(): void {
+		if (!this.isConnected()) return
+		this.broadcast({ type: 'action:start' })
+	}
+
+	/**
+	 * Broadcast an agent action end event to all connected extensions.
+	 * Used to hide the agent control halo in the extension.
+	 */
+	broadcastActionEnd(): void {
+		if (!this.isConnected()) return
+		this.broadcast({ type: 'action:end' })
+	}
+
+	/**
+	 * Broadcast a message to all connected extension sockets.
+	 */
+	private broadcast(message: Record<string, unknown>): void {
+		const data = JSON.stringify(message)
+		for (const socket of this.sockets) {
+			socket.send(data)
+		}
+	}
+
+	/**
 	 * Handle incoming websocket messages from the extension.
 	 */
 	handleMessage(_socket: PairedSocket, message: string | Uint8Array): void {


### PR DESCRIPTION
## Summary

Add a visual indicator that shows when the agent is actively controlling the browser in paired mode. A pulsing orange halo appears around the viewport during agent actions and disappears immediately when the user takes control.

## Behavior

| State | Visual |
|-------|--------|
| Agent executing action | Full-viewport orange halo, pulsing animation |
| Agent idle (paired connected) | Badge/sidebar indicator only |
| User takes action | Halo disappears immediately |
| Disconnected | Nothing |

## Changes

- **styles.css**: Added `.navigator-agent-control` class with orange glow and pulse animation
- **content/index.ts**: Added `showAgentHalo()`/`hideAgentHalo()` functions, message handlers for action lifecycle
- **background/index.ts**: Forwards `action:start`/`action:end` from server to content scripts
- **paired/manager.ts**: Added `broadcastActionStart()`/`broadcastActionEnd()` methods
- **executor.ts**: Notifies paired manager on action lifecycle

## Demo

The halo provides clear visual feedback that the agent is "driving" — not just that paired mode is connected. When the user clicks, types, or scrolls, the halo disappears instantly, indicating they've taken control.

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Manual test: Connect extension, trigger agent action, verify halo appears
- [ ] Manual test: Click/type/scroll while halo visible, verify it disappears

---

🤖 Generated with [Claude Code](https://claude.ai/code)