### PR TITLE
feat(core): add viewport context to markers

### DIFF
--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -29,6 +29,8 @@ export {
 	type Marker,
 	type MarkerCreateInput,
 	MarkerSchema,
+	type MarkerViewport,
+	MarkerViewportSchema,
 	type PointGeometry,
 	PointGeometrySchema,
 	type RegionGeometry,

--- a/packages/core/src/schema/marker.ts
+++ b/packages/core/src/schema/marker.ts
@@ -36,6 +36,24 @@ export const GeometrySchema = z.discriminatedUnion('type', [
 export type Geometry = z.infer<typeof GeometrySchema>
 
 // ============================================================================
+// Marker Viewport Context
+// ============================================================================
+
+/**
+ * Viewport context captured when a marker is created.
+ * Enables "scroll to same position" use cases and viewport normalization.
+ */
+export const MarkerViewportSchema = z.object({
+	width: z.number(),
+	height: z.number(),
+	scrollX: z.number(),
+	scrollY: z.number(),
+	devicePixelRatio: z.number(),
+})
+
+export type MarkerViewport = z.infer<typeof MarkerViewportSchema>
+
+// ============================================================================
 // Marker Schema
 // ============================================================================
 
@@ -48,6 +66,7 @@ export const MarkerSchema = z.object({
 	geometry: GeometrySchema,
 	note: z.string().optional(),
 	screenshot: z.string().optional(), // base64 or file path
+	viewport: MarkerViewportSchema.optional(),
 })
 
 export type Marker = z.infer<typeof MarkerSchema>
@@ -62,4 +81,5 @@ export interface MarkerCreateInput {
 	geometry: Geometry
 	note?: string | undefined
 	screenshot?: string | undefined
+	viewport?: MarkerViewport | undefined
 }

--- a/packages/server/src/actions/executor.ts
+++ b/packages/server/src/actions/executor.ts
@@ -13,6 +13,7 @@ import type {
 	ColorScheme,
 	FindAction,
 	Geometry,
+	MarkerViewport,
 	NavigatorConfig,
 	TabRef,
 	Viewport,
@@ -1460,12 +1461,31 @@ export class ActionExecutor {
 			}
 		}
 
+		// Capture viewport context
+		let viewport: MarkerViewport | undefined
+		const viewportResult = await this.browserManager.send<{
+			result?: MarkerViewport
+		}>({
+			action: 'evaluate',
+			script: `() => ({
+				width: window.innerWidth,
+				height: window.innerHeight,
+				scrollX: window.scrollX,
+				scrollY: window.scrollY,
+				devicePixelRatio: window.devicePixelRatio,
+			})`,
+		})
+		if (viewportResult.success && viewportResult.data?.result) {
+			viewport = viewportResult.data.result
+		}
+
 		const marker = await this.markerStore.create({
 			url,
 			title,
 			geometry,
 			note,
 			screenshot,
+			viewport,
 		})
 
 		return { success: true, data: marker }

--- a/packages/server/src/markers/store.ts
+++ b/packages/server/src/markers/store.ts
@@ -50,6 +50,7 @@ export class MarkerStore {
 			geometry: input.geometry,
 			note: input.note,
 			screenshot: input.screenshot,
+			viewport: input.viewport,
 		}
 
 		// Validate


### PR DESCRIPTION
## Summary

Store viewport context when creating markers to enable "scroll to same position" use cases and visual regression with viewport normalization.

## Changes

- **packages/core/src/schema/marker.ts**: Added `MarkerViewportSchema` with width, height, scrollX, scrollY, devicePixelRatio
- **packages/server/src/actions/executor.ts**: Capture viewport info via page evaluate at marker creation
- **packages/server/src/markers/store.ts**: Persist viewport field with marker

## New Marker Field

```typescript
viewport?: {
  width: number,        // window.innerWidth
  height: number,       // window.innerHeight
  scrollX: number,      // window.scrollX
  scrollY: number,      // window.scrollY
  devicePixelRatio: number
}
```

## Use Cases Enabled

- **Scroll restoration**: Navigate to marker and restore scroll position
- **Viewport normalization**: Adjust coordinates for different screen sizes in visual regression
- **Context preservation**: Know the exact viewport state when marker was created

## Backwards Compatibility

The `viewport` field is optional. Existing markers without viewport data continue to work.

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Create marker, verify viewport captured
- [ ] Load existing markers without viewport, verify no errors

---

🤖 Generated with [Claude Code](https://claude.ai/code)