### PR TITLE
feat(server): refactor screenshot storage to separate files

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,8 @@ export {
 	getDataHome,
 	getMarkerPath,
 	getMarkersDir,
+	getMarkerScreenshotsDir,
+	getMarkerScreenshotPath,
 	getNavigatorCacheDir,
 	getNavigatorConfigDir,
 	getNavigatorDataDir,

--- a/packages/core/src/schema/action.ts
+++ b/packages/core/src/schema/action.ts
@@ -274,11 +274,13 @@ const markersAction = z.object({
 const markerGetAction = z.object({
 	action: z.literal('markerGet'),
 	id: z.string().uuid(),
+	includeScreenshot: z.boolean().optional(),
 })
 
 const markerReadAction = z.object({
 	action: z.literal('markerRead'),
 	ids: z.array(z.string().uuid()).optional(),
+	includeScreenshot: z.boolean().optional(),
 })
 
 const markerDeleteAction = z.object({

--- a/packages/core/src/schema/marker.ts
+++ b/packages/core/src/schema/marker.ts
@@ -65,7 +65,7 @@ export const MarkerSchema = z.object({
 	title: z.string(),
 	geometry: GeometrySchema,
 	note: z.string().optional(),
-	screenshot: z.string().optional(), // base64 or file path
+	screenshotPath: z.string().optional(), // Relative path to screenshot file
 	viewport: MarkerViewportSchema.optional(),
 })
 

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -24,6 +24,8 @@ export {
 	// Marker paths
 	getMarkerPath,
 	getMarkersDir,
+	getMarkerScreenshotsDir,
+	getMarkerScreenshotPath,
 	// Session file paths
 	getSessionMetaPath,
 	getStepsPath,

--- a/packages/core/src/storage/paths.ts
+++ b/packages/core/src/storage/paths.ts
@@ -171,6 +171,39 @@ export function getMarkersDir(projectPath: string, sessionId: string): string {
 	return join(getSessionDir(projectPath, sessionId), 'markers')
 }
 
+/**
+ * Get marker screenshots directory within a session.
+ * ~/.local/share/navigator/{project-hash}/sessions/{session-id}/markers/screenshots/
+ *
+ * @param projectPath - Absolute path to project root
+ * @param sessionId - Session UUID
+ */
+export function getMarkerScreenshotsDir(
+	projectPath: string,
+	sessionId: string,
+): string {
+	return join(getMarkersDir(projectPath, sessionId), 'screenshots')
+}
+
+/**
+ * Get marker screenshot file path.
+ * ~/.local/share/navigator/{project-hash}/sessions/{session-id}/markers/screenshots/{marker-id}.png
+ *
+ * @param projectPath - Absolute path to project root
+ * @param sessionId - Session UUID
+ * @param markerId - Marker UUID
+ */
+export function getMarkerScreenshotPath(
+	projectPath: string,
+	sessionId: string,
+	markerId: string,
+): string {
+	return join(
+		getMarkerScreenshotsDir(projectPath, sessionId),
+		`${markerId}.png`,
+	)
+}
+
 // ============================================================================
 // File Paths within Session
 // ============================================================================

--- a/packages/server/src/actions/executor.ts
+++ b/packages/server/src/actions/executor.ts
@@ -322,9 +322,9 @@ export class ActionExecutor {
 			case 'markers':
 				return this.listMarkers(action.format)
 			case 'markerGet':
-				return this.getMarker(action.id)
+				return this.getMarker(action.id, action.includeScreenshot)
 			case 'markerRead':
-				return this.readMarkers(action.ids)
+				return this.readMarkers(action.ids, action.includeScreenshot)
 			case 'markerDelete':
 				return this.deleteMarker(action.id)
 			case 'markerCompare':
@@ -1622,7 +1622,10 @@ export class ActionExecutor {
 		return { success: true, data: markers }
 	}
 
-	private async getMarker(id: string): Promise<ActionResult> {
+	private async getMarker(
+		id: string,
+		includeScreenshot?: boolean,
+	): Promise<ActionResult> {
 		if (!this.markerStore) {
 			return createError(
 				'No active session',
@@ -1632,7 +1635,7 @@ export class ActionExecutor {
 			)
 		}
 
-		const marker = await this.markerStore.get(id)
+		const marker = await this.markerStore.get(id, { includeScreenshot })
 		if (!marker) {
 			return { success: false, error: `Marker not found: ${id}` }
 		}
@@ -1640,7 +1643,10 @@ export class ActionExecutor {
 		return { success: true, data: marker }
 	}
 
-	private async readMarkers(ids?: string[]): Promise<ActionResult> {
+	private async readMarkers(
+		ids?: string[],
+		includeScreenshot?: boolean,
+	): Promise<ActionResult> {
 		if (!this.markerStore) {
 			return createError(
 				'No active session',
@@ -1650,7 +1656,7 @@ export class ActionExecutor {
 			)
 		}
 
-		let markers = await this.markerStore.list()
+		let markers = await this.markerStore.list({ includeScreenshot })
 
 		if (ids && ids.length > 0) {
 			markers = markers.filter((m) => ids.includes(m.id))

--- a/packages/server/src/markers/index.ts
+++ b/packages/server/src/markers/index.ts
@@ -2,5 +2,9 @@
  * Markers module barrel export
  */
 
-export { MarkerStore } from './store'
+export {
+	MarkerStore,
+	type MarkerGetOptions,
+	type MarkerWithScreenshot,
+} from './store'
 export { markerSummary, markerToMarkdown, markersToMarkdown } from './markdown'

--- a/packages/server/src/markers/markdown.ts
+++ b/packages/server/src/markers/markdown.ts
@@ -7,14 +7,15 @@
  */
 
 import type { Marker } from '@outfitter/navigator-core'
+import type { MarkerWithScreenshot } from './store'
 
 /**
  * Convert multiple markers to markdown.
  *
- * @param markers - Array of markers
+ * @param markers - Array of markers (may include loaded screenshot data)
  * @returns Markdown string
  */
-export function markersToMarkdown(markers: Marker[]): string {
+export function markersToMarkdown(markers: MarkerWithScreenshot[]): string {
 	if (markers.length === 0) {
 		return '_No markers_'
 	}
@@ -41,13 +42,15 @@ export function markersToMarkdown(markers: Marker[]): string {
 			lines.push(`> ${marker.note}`)
 		}
 
+		// Handle loaded screenshot data (base64) or just show path reference
 		if (marker.screenshot) {
+			// Loaded screenshot data (base64)
 			lines.push('')
-			if (marker.screenshot.startsWith('data:')) {
-				lines.push(`![Marker screenshot](${marker.screenshot})`)
-			} else {
-				lines.push(`_Screenshot saved: ${marker.screenshot}_`)
-			}
+			lines.push(`![Marker screenshot](${marker.screenshot})`)
+		} else if (marker.screenshotPath) {
+			// Just the path reference (not loaded)
+			lines.push('')
+			lines.push(`_Screenshot: ${marker.screenshotPath}_`)
 		}
 
 		lines.push('')
@@ -61,10 +64,10 @@ export function markersToMarkdown(markers: Marker[]): string {
 /**
  * Convert a single marker to markdown.
  *
- * @param marker - Marker to convert
+ * @param marker - Marker to convert (may include loaded screenshot data)
  * @returns Markdown string
  */
-export function markerToMarkdown(marker: Marker): string {
+export function markerToMarkdown(marker: MarkerWithScreenshot): string {
 	return markersToMarkdown([marker])
 }
 

--- a/packages/server/src/markers/store.ts
+++ b/packages/server/src/markers/store.ts
@@ -2,6 +2,7 @@
  * Marker Store
  *
  * Persists markers to disk within session directories.
+ * Screenshots are stored as separate files in a screenshots/ subdirectory.
  *
  * @module markers/store
  */
@@ -15,41 +16,87 @@ import {
 	type MarkerCreateInput,
 	MarkerSchema,
 	getMarkerPath,
+	getMarkerScreenshotPath,
+	getMarkerScreenshotsDir,
 	getMarkersDir,
 } from '@outfitter/navigator-core'
 import { CATEGORIES, getLogger } from '@outfitter/navigator-core/logging'
 
 const log = getLogger(CATEGORIES.MARKERS)
 
+/** Options for retrieving markers */
+export interface MarkerGetOptions {
+	/** If true, load screenshot data as base64 and return in marker.screenshot */
+	includeScreenshot?: boolean | undefined
+}
+
+/** Marker with optional loaded screenshot data */
+export interface MarkerWithScreenshot extends Marker {
+	screenshot?: string
+}
+
 /**
  * Store for managing markers within a session.
  */
 export class MarkerStore {
 	private readonly markersDir: string
+	private readonly screenshotsDir: string
 
 	constructor(
 		private readonly projectRoot: string,
 		private readonly sessionId: string,
 	) {
 		this.markersDir = getMarkersDir(projectRoot, sessionId)
+		this.screenshotsDir = getMarkerScreenshotsDir(projectRoot, sessionId)
 	}
 
 	/**
 	 * Create a new marker.
 	 *
+	 * If screenshot data (base64) is provided in input, it will be written to a
+	 * separate file and the marker will store only the relative path.
+	 *
 	 * @param input - Marker creation input
 	 * @returns Created marker
 	 */
 	async create(input: MarkerCreateInput): Promise<Marker> {
+		const markerId = randomUUID()
+		let screenshotPath: string | undefined
+
+		// If screenshot data provided, write to file
+		if (input.screenshot) {
+			// Ensure screenshots directory exists
+			await mkdir(this.screenshotsDir, { recursive: true })
+
+			// Extract base64 data (remove data URL prefix if present)
+			const base64Data = input.screenshot.replace(
+				/^data:image\/\w+;base64,/,
+				'',
+			)
+
+			// Write screenshot to file
+			const screenshotFilePath = getMarkerScreenshotPath(
+				this.projectRoot,
+				this.sessionId,
+				markerId,
+			)
+			await writeFile(screenshotFilePath, Buffer.from(base64Data, 'base64'))
+
+			// Store relative path (relative to markers directory)
+			screenshotPath = `screenshots/${markerId}.png`
+
+			log.debug`Screenshot saved ${{ markerId, path: screenshotPath }}`
+		}
+
 		const marker: Marker = {
-			id: randomUUID(),
+			id: markerId,
 			sessionId: this.sessionId,
 			timestamp: new Date().toISOString(),
 			url: input.url,
 			title: input.title,
 			geometry: input.geometry,
 			note: input.note,
-			screenshot: input.screenshot,
+			screenshotPath,
 			viewport: input.viewport,
 		}
 
@@ -75,36 +122,96 @@ export class MarkerStore {
 	 * Get a marker by ID.
 	 *
 	 * @param markerId - Marker UUID
+	 * @param options - Options for retrieval
 	 * @returns Marker or null if not found
 	 */
-	async get(markerId: string): Promise<Marker | null> {
+	async get(
+		markerId: string,
+		options?: MarkerGetOptions,
+	): Promise<MarkerWithScreenshot | null> {
 		const markerPath = getMarkerPath(this.projectRoot, this.sessionId, markerId)
 		if (!existsSync(markerPath)) {
 			log.debug`Marker not found ${{ id: markerId }}`
 			return null
 		}
 		const raw = await readFile(markerPath, 'utf8')
+		const rawJson = JSON.parse(raw) as Record<string, unknown>
+		const marker = MarkerSchema.parse(rawJson)
+
+		// Optionally load screenshot data
+		if (options?.includeScreenshot) {
+			// Check for new separate file storage
+			if (marker.screenshotPath) {
+				const screenshotData = this.loadScreenshot(markerId)
+				if (screenshotData) {
+					log.debug`Marker retrieved with screenshot ${{ id: markerId }}`
+					return { ...marker, screenshot: screenshotData }
+				}
+			}
+			// Fallback: check for legacy inline screenshot (pre-refactor markers)
+			if (typeof rawJson.screenshot === 'string' && rawJson.screenshot.length > 0) {
+				log.debug`Marker retrieved with legacy inline screenshot ${{ id: markerId }}`
+				return { ...marker, screenshot: rawJson.screenshot }
+			}
+		}
+
 		log.debug`Marker retrieved ${{ id: markerId }}`
-		return MarkerSchema.parse(JSON.parse(raw))
+		return marker
+	}
+
+	/**
+	 * Load screenshot data for a marker.
+	 *
+	 * @param markerId - Marker UUID
+	 * @returns Base64 data URL or null if not found
+	 */
+	private loadScreenshot(markerId: string): string | null {
+		const screenshotPath = getMarkerScreenshotPath(
+			this.projectRoot,
+			this.sessionId,
+			markerId,
+		)
+		if (!existsSync(screenshotPath)) {
+			return null
+		}
+		try {
+			const buffer = readFileSync(screenshotPath)
+			return `data:image/png;base64,${buffer.toString('base64')}`
+		} catch {
+			log.debug`Failed to load screenshot ${{ markerId }}`
+			return null
+		}
 	}
 
 	/**
 	 * List all markers in the session.
 	 *
+	 * @param options - Options for retrieval
 	 * @returns Array of markers sorted by timestamp (newest first)
 	 */
-	async list(): Promise<Marker[]> {
+	async list(options?: MarkerGetOptions): Promise<MarkerWithScreenshot[]> {
 		if (!existsSync(this.markersDir)) return []
 
 		const files = readdirSync(this.markersDir).filter((f) =>
 			f.endsWith('.json'),
 		)
-		const markers: Marker[] = []
+		const markers: MarkerWithScreenshot[] = []
 
 		for (const file of files) {
 			try {
 				const raw = readFileSync(join(this.markersDir, file), 'utf8')
-				markers.push(MarkerSchema.parse(JSON.parse(raw)))
+				const marker = MarkerSchema.parse(JSON.parse(raw))
+
+				// Optionally load screenshot data
+				if (options?.includeScreenshot && marker.screenshotPath) {
+					const screenshotData = this.loadScreenshot(marker.id)
+					if (screenshotData) {
+						markers.push({ ...marker, screenshot: screenshotData })
+						continue
+					}
+				}
+
+				markers.push(marker)
 			} catch {
 				// Skip invalid markers
 			}
@@ -147,7 +254,7 @@ export class MarkerStore {
 	}
 
 	/**
-	 * Delete a marker.
+	 * Delete a marker and its associated screenshot file.
 	 *
 	 * @param markerId - Marker UUID
 	 * @returns True if deleted, false if not found
@@ -158,6 +265,22 @@ export class MarkerStore {
 			log.debug`Marker not found for deletion ${{ id: markerId }}`
 			return false
 		}
+
+		// Delete screenshot file if it exists
+		const screenshotPath = getMarkerScreenshotPath(
+			this.projectRoot,
+			this.sessionId,
+			markerId,
+		)
+		if (existsSync(screenshotPath)) {
+			try {
+				unlinkSync(screenshotPath)
+				log.debug`Screenshot deleted ${{ markerId }}`
+			} catch {
+				log.debug`Failed to delete screenshot ${{ markerId }}`
+			}
+		}
+
 		unlinkSync(markerPath)
 		log.debug`Marker deleted ${{ id: markerId }}`
 		return true


### PR DESCRIPTION
## Summary

Move marker screenshots from inline base64 in JSON to separate files with lazy loading support. Reduces marker JSON size from ~40KB to <1KB, dramatically improving agent context efficiency.

## Before

```json
{
  "id": "abc123",
  "geometry": { "type": "point", "x": 100, "y": 100 },
  "screenshot": "data:image/png;base64,iVBORw0KGgo...40KB..."
}
```

## After

```json
{
  "id": "abc123", 
  "geometry": { "type": "point", "x": 100, "y": 100 },
  "screenshotPath": "screenshots/abc123.png"
}
```

## File Structure

```
markers/
├── {marker-id}.json           # Metadata only (~1KB)
├── screenshots/
│   ├── {marker-id}.png        # Binary screenshot
│   └── ...
```

## Changes

- **packages/core/src/schema/marker.ts**: Changed `screenshot` to `screenshotPath`
- **packages/core/src/storage/paths.ts**: Added `getMarkerScreenshotPath()` helper
- **packages/core/src/schema/action.ts**: Added `includeScreenshot` flag to markerGet/markerRead
- **packages/server/src/markers/store.ts**: Write screenshots to files, lazy load on request

## API Changes

```typescript
// Default: returns path only
{ action: "markerGet", id: "abc123" }
// → { screenshotPath: "screenshots/abc123.png" }

// With flag: returns base64 data
{ action: "markerGet", id: "abc123", includeScreenshot: true }
// → { screenshotPath: "...", screenshot: "data:image/png;base64,..." }
```

## Agent Benefits

| Use Case | Before | After |
|----------|--------|-------|
| List 3 markers | ~120KB | ~3KB |
| Get marker for visual diff | 40KB | 40KB (with flag) |
| Reference marker by ID | 40KB | <1KB |

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Create marker, verify screenshot saved as separate file
- [ ] markerGet without flag returns path only
- [ ] markerGet with includeScreenshot returns base64

---

🤖 Generated with [Claude Code](https://claude.ai/code)