### PR TITLE
fix(server,cli): return ELEMENT_NOT_FOUND for invalid element refs

### DIFF
--- a/packages/cli/src/commands/interaction.ts
+++ b/packages/cli/src/commands/interaction.ts
@@ -13,6 +13,35 @@ import type { NavigatorClient } from '../client.js'
 /** Matches element refs like e42 or e42_1 or @e42 */
 const ELEMENT_REF_REGEX = /^@?e\d+(?:_\d+)?$/
 
+/** Result type for action execution */
+interface ActionResult {
+	success: boolean
+	error?: string
+	errorCode?: string
+	retryable?: boolean
+	suggestedFix?: string
+}
+
+/**
+ * Check if result is an error and handle it.
+ * Returns true if there was an error (caller should not print success message).
+ */
+function handleActionResult(result: unknown): boolean {
+	const r = result as ActionResult
+	if (r && r.success === false) {
+		console.error(`Error: ${r.error ?? 'Unknown error'}`)
+		if (r.errorCode) {
+			console.error(`  Code: ${r.errorCode}`)
+		}
+		if (r.suggestedFix) {
+			console.error(`  Fix: ${r.suggestedFix}`)
+		}
+		process.exitCode = 1
+		return true
+	}
+	return false
+}
+
 /** Snap result with optional multi-viewport data */
 interface SnapResult {
 	tree?: string
@@ -138,12 +167,14 @@ export function registerInteractionCommands(
 		.action(async (target: string, options) => {
 			const client = getClient()
 			const parsedTarget = parseTarget(target)
-			await client.execute({
+			const result = await client.execute({
 				action: 'click',
 				...parsedTarget,
 				clickCount: options.dbl ? 2 : 1,
 			})
-			console.log('Clicked:', target)
+			if (!handleActionResult(result)) {
+				console.log('Clicked:', target)
+			}
 		})
 
 	// nav type <ref|selector> <text>
@@ -154,13 +185,15 @@ export function registerInteractionCommands(
 		.action(async (target: string, text: string, options) => {
 			const client = getClient()
 			const parsedTarget = parseTarget(target)
-			await client.execute({
+			const result = await client.execute({
 				action: 'type',
 				...parsedTarget,
 				text,
 				clear: options.clear,
 			})
-			console.log('Typed into:', target)
+			if (!handleActionResult(result)) {
+				console.log('Typed into:', target)
+			}
 		})
 
 	// nav press <key-combo>
@@ -192,12 +225,14 @@ export function registerInteractionCommands(
 		.action(async (target: string, text: string) => {
 			const client = getClient()
 			const parsedTarget = parseTarget(target)
-			await client.execute({
+			const result = await client.execute({
 				action: 'fill',
 				...parsedTarget,
 				value: text,
 			})
-			console.log('Filled:', target)
+			if (!handleActionResult(result)) {
+				console.log('Filled:', target)
+			}
 		})
 
 	// nav select <ref|selector> <value>
@@ -207,12 +242,14 @@ export function registerInteractionCommands(
 		.action(async (target: string, value: string) => {
 			const client = getClient()
 			const parsedTarget = parseTarget(target)
-			await client.execute({
+			const result = await client.execute({
 				action: 'select',
 				...parsedTarget,
 				value,
 			})
-			console.log('Selected:', value, 'in', target)
+			if (!handleActionResult(result)) {
+				console.log('Selected:', value, 'in', target)
+			}
 		})
 
 	// nav hover <ref|selector>
@@ -222,11 +259,13 @@ export function registerInteractionCommands(
 		.action(async (target: string) => {
 			const client = getClient()
 			const parsedTarget = parseTarget(target)
-			await client.execute({
+			const result = await client.execute({
 				action: 'hover',
 				...parsedTarget,
 			})
-			console.log('Hovering:', target)
+			if (!handleActionResult(result)) {
+				console.log('Hovering:', target)
+			}
 		})
 
 	// nav scroll <direction> [amount]
@@ -349,11 +388,13 @@ export function registerInteractionCommands(
 		.action(async (target: string) => {
 			const client = getClient()
 			const parsedTarget = parseTarget(target)
-			await client.execute({
+			const result = await client.execute({
 				action: 'check',
 				...parsedTarget,
 			})
-			console.log('Checked:', target)
+			if (!handleActionResult(result)) {
+				console.log('Checked:', target)
+			}
 		})
 
 	// nav interact uncheck <ref|selector>
@@ -363,11 +404,13 @@ export function registerInteractionCommands(
 		.action(async (target: string) => {
 			const client = getClient()
 			const parsedTarget = parseTarget(target)
-			await client.execute({
+			const result = await client.execute({
 				action: 'uncheck',
 				...parsedTarget,
 			})
-			console.log('Unchecked:', target)
+			if (!handleActionResult(result)) {
+				console.log('Unchecked:', target)
+			}
 		})
 
 	// nav interact upload <ref|selector> <files...>
@@ -379,12 +422,14 @@ export function registerInteractionCommands(
 			const parsedTarget = parseTarget(target)
 			// Resolve file paths to absolute
 			const resolvedFiles = files.map((f) => resolve(f))
-			await client.execute({
+			const result = await client.execute({
 				action: 'upload',
 				...parsedTarget,
 				files: resolvedFiles,
 			})
-			console.log('Uploaded to:', target, 'files:', resolvedFiles.join(', '))
+			if (!handleActionResult(result)) {
+				console.log('Uploaded to:', target, 'files:', resolvedFiles.join(', '))
+			}
 		})
 
 	// nav interact dialog <action> [value]

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -141,7 +141,9 @@ export function loadConfig(): Config {
 		// If parsing fails, return defaults but always notify the user
 		// Write to stderr directly since logging may not be configured yet
 		const message = error instanceof Error ? error.message : String(error)
-		console.error(`[navigator] Warning: Failed to parse config at ${configPath}: ${message}`)
+		console.error(
+			`[navigator] Warning: Failed to parse config at ${configPath}: ${message}`,
+		)
 		console.error('[navigator] Using default configuration')
 		log.warning`Failed to parse config at ${configPath}: ${error}`
 		return ConfigSchema.parse({})

--- a/packages/server/src/actions/executor.ts
+++ b/packages/server/src/actions/executor.ts
@@ -85,6 +85,8 @@ export class ActionExecutor {
 	private markerStore: MarkerStore | null = null
 	private stepLogger: StepLogger | null = null
 	private currentProjectRoot: string | null = null
+	private hasSnapshot = false
+	private lastInteractiveCount = 0
 
 	constructor(
 		private readonly browserManager: BrowserManager,
@@ -262,6 +264,9 @@ export class ActionExecutor {
 			this.currentProjectRoot = effectiveProjectRoot
 			this.markerStore = new MarkerStore(effectiveProjectRoot, session.id)
 			this.stepLogger = new StepLogger(effectiveProjectRoot, session.id)
+			// Reset snapshot state when project root changes
+			this.hasSnapshot = false
+			this.lastInteractiveCount = 0
 		}
 
 		const start = Date.now()
@@ -698,12 +703,53 @@ export class ActionExecutor {
 			)
 		}
 
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
+		}
+
 		const response = await this.sendCommand(
 			{ action: 'click', selector: target, button, clickCount },
 			tab,
 		)
 		if (!response.success) {
-			return { success: false, error: response.error ?? 'Click failed' }
+			const errorMsg = response.error ?? 'Click failed'
+			const lowerError = errorMsg.toLowerCase()
+
+			let errorCode: ErrorCode = ErrorCode.ELEMENT_NOT_FOUND
+			let retryable = true
+			let recovery = 'Take a fresh snap to get updated element references'
+
+			if (lowerError.includes('not visible') || lowerError.includes('hidden')) {
+				errorCode = ErrorCode.ELEMENT_NOT_VISIBLE
+				recovery =
+					'Element exists but is hidden - wait for visibility or scroll into view'
+			} else if (
+				lowerError.includes('not interactable') ||
+				lowerError.includes('pointer events')
+			) {
+				errorCode = ErrorCode.ELEMENT_NOT_INTERACTABLE
+				recovery =
+					'Element is covered or disabled - wait or click covering element first'
+			} else if (
+				lowerError.includes('stale') ||
+				lowerError.includes('detached')
+			) {
+				errorCode = ErrorCode.STALE_REF
+				recovery = 'Element was removed from DOM - take a new snap and retry'
+			} else if (
+				lowerError.includes('invalid selector') ||
+				lowerError.includes('syntax error')
+			) {
+				errorCode = ErrorCode.SELECTOR_INVALID
+				retryable = false
+				recovery = 'Check selector syntax - use CSS or ref from snap'
+			}
+
+			return createError(errorMsg, errorCode, retryable, recovery)
 		}
 		return { success: true }
 	}
@@ -726,12 +772,53 @@ export class ActionExecutor {
 			)
 		}
 
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
+		}
+
 		const response = await this.sendCommand(
 			{ action: 'type', selector: target, text, clear, delay },
 			tab,
 		)
 		if (!response.success) {
-			return { success: false, error: response.error ?? 'Type failed' }
+			const errorMsg = response.error ?? 'Type failed'
+			const lowerError = errorMsg.toLowerCase()
+
+			let errorCode: ErrorCode = ErrorCode.ELEMENT_NOT_FOUND
+			let retryable = true
+			let recovery = 'Take a fresh snap to get updated element references'
+
+			if (lowerError.includes('not visible') || lowerError.includes('hidden')) {
+				errorCode = ErrorCode.ELEMENT_NOT_VISIBLE
+				recovery =
+					'Element exists but is hidden - wait for visibility or scroll into view'
+			} else if (
+				lowerError.includes('not interactable') ||
+				lowerError.includes('pointer events')
+			) {
+				errorCode = ErrorCode.ELEMENT_NOT_INTERACTABLE
+				recovery =
+					'Element is covered or disabled - wait or click covering element first'
+			} else if (
+				lowerError.includes('stale') ||
+				lowerError.includes('detached')
+			) {
+				errorCode = ErrorCode.STALE_REF
+				recovery = 'Element was removed from DOM - take a new snap and retry'
+			} else if (
+				lowerError.includes('invalid selector') ||
+				lowerError.includes('syntax error')
+			) {
+				errorCode = ErrorCode.SELECTOR_INVALID
+				retryable = false
+				recovery = 'Check selector syntax - use CSS or ref from snap'
+			}
+
+			return createError(errorMsg, errorCode, retryable, recovery)
 		}
 		return { success: true }
 	}
@@ -752,12 +839,53 @@ export class ActionExecutor {
 			)
 		}
 
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
+		}
+
 		const response = await this.sendCommand(
 			{ action: 'select', selector: target, values: value },
 			tab,
 		)
 		if (!response.success) {
-			return { success: false, error: response.error ?? 'Select failed' }
+			const errorMsg = response.error ?? 'Select failed'
+			const lowerError = errorMsg.toLowerCase()
+
+			let errorCode: ErrorCode = ErrorCode.ELEMENT_NOT_FOUND
+			let retryable = true
+			let recovery = 'Take a fresh snap to get updated element references'
+
+			if (lowerError.includes('not visible') || lowerError.includes('hidden')) {
+				errorCode = ErrorCode.ELEMENT_NOT_VISIBLE
+				recovery =
+					'Element exists but is hidden - wait for visibility or scroll into view'
+			} else if (
+				lowerError.includes('not interactable') ||
+				lowerError.includes('pointer events')
+			) {
+				errorCode = ErrorCode.ELEMENT_NOT_INTERACTABLE
+				recovery =
+					'Element is covered or disabled - wait or click covering element first'
+			} else if (
+				lowerError.includes('stale') ||
+				lowerError.includes('detached')
+			) {
+				errorCode = ErrorCode.STALE_REF
+				recovery = 'Element was removed from DOM - take a new snap and retry'
+			} else if (
+				lowerError.includes('invalid selector') ||
+				lowerError.includes('syntax error')
+			) {
+				errorCode = ErrorCode.SELECTOR_INVALID
+				retryable = false
+				recovery = 'Check selector syntax - use CSS or ref from snap'
+			}
+
+			return createError(errorMsg, errorCode, retryable, recovery)
 		}
 		return { success: true }
 	}
@@ -777,12 +905,53 @@ export class ActionExecutor {
 			)
 		}
 
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
+		}
+
 		const response = await this.sendCommand(
 			{ action: 'hover', selector: target },
 			tab,
 		)
 		if (!response.success) {
-			return { success: false, error: response.error ?? 'Hover failed' }
+			const errorMsg = response.error ?? 'Hover failed'
+			const lowerError = errorMsg.toLowerCase()
+
+			let errorCode: ErrorCode = ErrorCode.ELEMENT_NOT_FOUND
+			let retryable = true
+			let recovery = 'Take a fresh snap to get updated element references'
+
+			if (lowerError.includes('not visible') || lowerError.includes('hidden')) {
+				errorCode = ErrorCode.ELEMENT_NOT_VISIBLE
+				recovery =
+					'Element exists but is hidden - wait for visibility or scroll into view'
+			} else if (
+				lowerError.includes('not interactable') ||
+				lowerError.includes('pointer events')
+			) {
+				errorCode = ErrorCode.ELEMENT_NOT_INTERACTABLE
+				recovery =
+					'Element is covered or disabled - wait or click covering element first'
+			} else if (
+				lowerError.includes('stale') ||
+				lowerError.includes('detached')
+			) {
+				errorCode = ErrorCode.STALE_REF
+				recovery = 'Element was removed from DOM - take a new snap and retry'
+			} else if (
+				lowerError.includes('invalid selector') ||
+				lowerError.includes('syntax error')
+			) {
+				errorCode = ErrorCode.SELECTOR_INVALID
+				retryable = false
+				recovery = 'Check selector syntax - use CSS or ref from snap'
+			}
+
+			return createError(errorMsg, errorCode, retryable, recovery)
 		}
 		return { success: true }
 	}
@@ -802,12 +971,53 @@ export class ActionExecutor {
 			)
 		}
 
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
+		}
+
 		const response = await this.sendCommand(
 			{ action: 'focus', selector: target },
 			tab,
 		)
 		if (!response.success) {
-			return { success: false, error: response.error ?? 'Focus failed' }
+			const errorMsg = response.error ?? 'Focus failed'
+			const lowerError = errorMsg.toLowerCase()
+
+			let errorCode: ErrorCode = ErrorCode.ELEMENT_NOT_FOUND
+			let retryable = true
+			let recovery = 'Take a fresh snap to get updated element references'
+
+			if (lowerError.includes('not visible') || lowerError.includes('hidden')) {
+				errorCode = ErrorCode.ELEMENT_NOT_VISIBLE
+				recovery =
+					'Element exists but is hidden - wait for visibility or scroll into view'
+			} else if (
+				lowerError.includes('not interactable') ||
+				lowerError.includes('pointer events')
+			) {
+				errorCode = ErrorCode.ELEMENT_NOT_INTERACTABLE
+				recovery =
+					'Element is covered or disabled - wait or click covering element first'
+			} else if (
+				lowerError.includes('stale') ||
+				lowerError.includes('detached')
+			) {
+				errorCode = ErrorCode.STALE_REF
+				recovery = 'Element was removed from DOM - take a new snap and retry'
+			} else if (
+				lowerError.includes('invalid selector') ||
+				lowerError.includes('syntax error')
+			) {
+				errorCode = ErrorCode.SELECTOR_INVALID
+				retryable = false
+				recovery = 'Check selector syntax - use CSS or ref from snap'
+			}
+
+			return createError(errorMsg, errorCode, retryable, recovery)
 		}
 		return { success: true }
 	}
@@ -866,12 +1076,53 @@ export class ActionExecutor {
 			)
 		}
 
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
+		}
+
 		const response = await this.sendCommand(
 			{ action: 'fill', selector: target, value },
 			tab,
 		)
 		if (!response.success) {
-			return { success: false, error: response.error ?? 'Fill failed' }
+			const errorMsg = response.error ?? 'Fill failed'
+			const lowerError = errorMsg.toLowerCase()
+
+			let errorCode: ErrorCode = ErrorCode.ELEMENT_NOT_FOUND
+			let retryable = true
+			let recovery = 'Take a fresh snap to get updated element references'
+
+			if (lowerError.includes('not visible') || lowerError.includes('hidden')) {
+				errorCode = ErrorCode.ELEMENT_NOT_VISIBLE
+				recovery =
+					'Element exists but is hidden - wait for visibility or scroll into view'
+			} else if (
+				lowerError.includes('not interactable') ||
+				lowerError.includes('pointer events')
+			) {
+				errorCode = ErrorCode.ELEMENT_NOT_INTERACTABLE
+				recovery =
+					'Element is covered or disabled - wait or click covering element first'
+			} else if (
+				lowerError.includes('stale') ||
+				lowerError.includes('detached')
+			) {
+				errorCode = ErrorCode.STALE_REF
+				recovery = 'Element was removed from DOM - take a new snap and retry'
+			} else if (
+				lowerError.includes('invalid selector') ||
+				lowerError.includes('syntax error')
+			) {
+				errorCode = ErrorCode.SELECTOR_INVALID
+				retryable = false
+				recovery = 'Check selector syntax - use CSS or ref from snap'
+			}
+
+			return createError(errorMsg, errorCode, retryable, recovery)
 		}
 		return { success: true }
 	}
@@ -1080,6 +1331,14 @@ export class ActionExecutor {
 			)
 		}
 
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
+		}
+
 		const response = await this.sendCommand(
 			{ action: 'check', selector: target },
 			tab,
@@ -1103,6 +1362,14 @@ export class ActionExecutor {
 				false,
 				'Provide ref from snap (e.g., "e42") or CSS selector',
 			)
+		}
+
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
 		}
 
 		const response = await this.sendCommand(
@@ -1129,6 +1396,14 @@ export class ActionExecutor {
 				false,
 				'Provide ref from snap (e.g., "e42") or CSS selector',
 			)
+		}
+
+		// Pre-validate element ref before sending to agent-browser
+		if (ref) {
+			const validation = this.validateElementRef(ref)
+			if (!validation.valid) {
+				return this.createElementRefError(ref)
+			}
 		}
 
 		const response = await this.sendCommand(
@@ -1183,7 +1458,8 @@ export class ActionExecutor {
 			tab,
 		)
 		if (!response.success) {
-			const errorMsg = response.error ?? `Timeout waiting for element to be ${state}`
+			const errorMsg =
+				response.error ?? `Timeout waiting for element to be ${state}`
 			const lowerError = errorMsg.toLowerCase()
 
 			// Determine appropriate error code based on error message
@@ -1191,11 +1467,17 @@ export class ActionExecutor {
 			let retryable = true
 			let recovery = 'Increase timeout or verify element exists with snap'
 
-			if (lowerError.includes('invalid selector') || lowerError.includes('syntax error')) {
+			if (
+				lowerError.includes('invalid selector') ||
+				lowerError.includes('syntax error')
+			) {
 				errorCode = ErrorCode.SELECTOR_INVALID
 				retryable = false
 				recovery = 'Check selector syntax - use CSS or ref from snap'
-			} else if (lowerError.includes('stale') || lowerError.includes('detached')) {
+			} else if (
+				lowerError.includes('stale') ||
+				lowerError.includes('detached')
+			) {
 				errorCode = ErrorCode.STALE_REF
 				retryable = true
 				recovery = 'Element was removed from DOM - take a new snap and retry'
@@ -1325,6 +1607,7 @@ export class ActionExecutor {
 			selector: 'body',
 		})
 		const text = textResult.success ? (textResult.data?.text ?? '') : ''
+		this.hasSnapshot = true
 		this.browserManager.incrementSnapshotVersion()
 		return {
 			success: true,
@@ -1375,6 +1658,11 @@ export class ActionExecutor {
 			version,
 		)
 		const refs = response.data.refs ?? {}
+		const interactiveCount = Object.keys(refs).length
+
+		// Store for element ref validation
+		this.hasSnapshot = true
+		this.lastInteractiveCount = interactiveCount
 
 		this.browserManager.incrementSnapshotVersion()
 		return {
@@ -1386,7 +1674,7 @@ export class ActionExecutor {
 				title,
 				tree: snapshotText,
 				mode: mode ?? 'full',
-				interactiveCount: Object.keys(refs).length,
+				interactiveCount,
 			},
 		}
 	}
@@ -2111,6 +2399,49 @@ export class ActionExecutor {
 		}
 		if (selector) return selector
 		return null
+	}
+
+	/**
+	 * Validate an element reference against the last snapshot.
+	 *
+	 * @param ref - Element reference (e.g., "@e42", "e42")
+	 * @returns Object with valid flag and parsed index
+	 */
+	private validateElementRef(ref: string): { valid: boolean; index: number } {
+		const match = ref.match(/^@?e(\d+)/)
+		if (!match?.[1]) return { valid: false, index: -1 }
+		const index = Number.parseInt(match[1], 10)
+
+		// If no snapshot taken yet, validation fails
+		if (!this.hasSnapshot) return { valid: false, index }
+
+		// If snapshot was taken but has 0 interactive elements (e.g., text_only mode),
+		// skip validation and let the action proceed to browser level
+		if (this.lastInteractiveCount === 0) return { valid: true, index }
+
+		// Element refs are 1-indexed, so valid range is 1 to interactiveCount
+		const valid = index >= 1 && index <= this.lastInteractiveCount
+		return { valid, index }
+	}
+
+	/**
+	 * Create an error result for invalid element references.
+	 */
+	private createElementRefError(ref: string): ActionResult {
+		if (!this.hasSnapshot) {
+			return createError(
+				`Cannot interact with ${ref}: no snapshot taken yet. Run snap first.`,
+				ErrorCode.ELEMENT_NOT_FOUND,
+				true,
+				'Take a snap first to discover interactive elements',
+			)
+		}
+		return createError(
+			`Element ${ref} not found. Last snap had ${this.lastInteractiveCount} interactive elements (e1-e${this.lastInteractiveCount}).`,
+			ErrorCode.ELEMENT_NOT_FOUND,
+			true,
+			'Take a fresh snap to get updated element references',
+		)
 	}
 
 	/**

--- a/packages/server/src/markers/store.ts
+++ b/packages/server/src/markers/store.ts
@@ -149,7 +149,10 @@ export class MarkerStore {
 				}
 			}
 			// Fallback: check for legacy inline screenshot (pre-refactor markers)
-			if (typeof rawJson.screenshot === 'string' && rawJson.screenshot.length > 0) {
+			if (
+				typeof rawJson.screenshot === 'string' &&
+				rawJson.screenshot.length > 0
+			) {
 				log.debug`Marker retrieved with legacy inline screenshot ${{ id: markerId }}`
 				return { ...marker, screenshot: rawJson.screenshot }
 			}

--- a/packages/server/tests/executors/checkbox.test.ts
+++ b/packages/server/tests/executors/checkbox.test.ts
@@ -13,6 +13,7 @@ import {
 	MockSessionManager,
 	createDefaultHandler,
 	createTestConfig,
+	simulateSnapshot,
 } from '../helpers/mock-managers'
 
 describe('check/uncheck action executors', () => {
@@ -21,7 +22,7 @@ describe('check/uncheck action executors', () => {
 	let pairedManager: MockPairedManager
 	let sessionManager: MockSessionManager
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		browserManager = new MockBrowserManager()
 		pairedManager = new MockPairedManager()
 		sessionManager = new MockSessionManager()
@@ -33,6 +34,9 @@ describe('check/uncheck action executors', () => {
 			sessionManager as unknown as Parameters<typeof ActionExecutor>[2],
 			createTestConfig(),
 		)
+
+		// Simulate taking a snapshot to enable element ref validation
+		await simulateSnapshot(executor)
 	})
 
 	describe('check action', () => {

--- a/packages/server/tests/executors/element-ref-validation.test.ts
+++ b/packages/server/tests/executors/element-ref-validation.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for element ref pre-validation.
+ *
+ * Element refs must be validated against the last snapshot before
+ * being sent to agent-browser. This prevents false success responses
+ * when clicking non-existent elements.
+ */
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { ErrorCode } from '@outfitter/navigator-core'
+import { ActionExecutor } from '../../src/actions/executor'
+import {
+	MockBrowserManager,
+	MockPairedManager,
+	MockSessionManager,
+	createDefaultHandler,
+	createTestConfig,
+	simulateSnapshot,
+} from '../helpers/mock-managers'
+
+describe('element ref validation', () => {
+	let executor: ActionExecutor
+	let browserManager: MockBrowserManager
+	let pairedManager: MockPairedManager
+	let sessionManager: MockSessionManager
+
+	beforeEach(() => {
+		browserManager = new MockBrowserManager()
+		pairedManager = new MockPairedManager()
+		sessionManager = new MockSessionManager()
+		browserManager.onSend(createDefaultHandler({ interactiveCount: 10 }))
+
+		executor = new ActionExecutor(
+			browserManager as unknown as Parameters<typeof ActionExecutor>[0],
+			pairedManager as unknown as Parameters<typeof ActionExecutor>[1],
+			sessionManager as unknown as Parameters<typeof ActionExecutor>[2],
+			createTestConfig(),
+		)
+	})
+
+	describe('without snapshot', () => {
+		test('click fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'click',
+				ref: '@e1',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+			expect(result.errorCode).toBe(ErrorCode.ELEMENT_NOT_FOUND)
+			expect(result.suggestedFix).toContain('snap first')
+		})
+
+		test('type fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'type',
+				ref: '@e1',
+				text: 'hello',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+		})
+
+		test('fill fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'fill',
+				ref: '@e1',
+				value: 'test',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+		})
+
+		test('hover fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'hover',
+				ref: '@e1',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+		})
+
+		test('focus fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'focus',
+				ref: '@e1',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+		})
+
+		test('check fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'check',
+				ref: '@e1',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+		})
+
+		test('uncheck fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'uncheck',
+				ref: '@e1',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+		})
+
+		test('upload fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'upload',
+				ref: '@e1',
+				files: ['./file.png'],
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+		})
+
+		test('select fails when no snapshot taken', async () => {
+			const result = await executor.execute({
+				action: 'select',
+				ref: '@e1',
+				value: 'option1',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('no snapshot taken yet')
+		})
+
+		test('CSS selector still works without snapshot', async () => {
+			const result = await executor.execute({
+				action: 'click',
+				selector: '#button',
+			})
+
+			expect(result.success).toBe(true)
+		})
+	})
+
+	describe('with snapshot', () => {
+		beforeEach(async () => {
+			// Take a snapshot with 10 elements
+			await simulateSnapshot(executor)
+		})
+
+		test('click succeeds for valid element ref', async () => {
+			const result = await executor.execute({
+				action: 'click',
+				ref: '@e1',
+			})
+
+			expect(result.success).toBe(true)
+		})
+
+		test('click succeeds for last valid element ref', async () => {
+			const result = await executor.execute({
+				action: 'click',
+				ref: '@e10',
+			})
+
+			expect(result.success).toBe(true)
+		})
+
+		test('click fails for element ref beyond count', async () => {
+			const result = await executor.execute({
+				action: 'click',
+				ref: '@e11',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('Element @e11 not found')
+			expect(result.error).toContain('e1-e10')
+			expect(result.errorCode).toBe(ErrorCode.ELEMENT_NOT_FOUND)
+			expect(result.suggestedFix).toContain('fresh snap')
+		})
+
+		test('click fails for very large element ref', async () => {
+			const result = await executor.execute({
+				action: 'click',
+				ref: '@e99999999',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('Element @e99999999 not found')
+		})
+
+		test('click fails for element ref e0 (refs are 1-indexed)', async () => {
+			const result = await executor.execute({
+				action: 'click',
+				ref: '@e0',
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.error).toContain('Element @e0 not found')
+		})
+
+		test('click succeeds with ref without @ prefix', async () => {
+			const result = await executor.execute({
+				action: 'click',
+				ref: 'e5',
+			})
+
+			expect(result.success).toBe(true)
+		})
+
+		test('click validates versioned ref correctly', async () => {
+			// e5_1 should extract index 5, which is valid for 10 elements
+			const result = await executor.execute({
+				action: 'click',
+				ref: '@e5_1',
+			})
+
+			expect(result.success).toBe(true)
+		})
+
+		test('type validates element ref', async () => {
+			const resultValid = await executor.execute({
+				action: 'type',
+				ref: '@e5',
+				text: 'hello',
+			})
+			expect(resultValid.success).toBe(true)
+
+			const resultInvalid = await executor.execute({
+				action: 'type',
+				ref: '@e100',
+				text: 'hello',
+			})
+			expect(resultInvalid.success).toBe(false)
+			expect(resultInvalid.error).toContain('Element @e100 not found')
+		})
+
+		test('hover validates element ref', async () => {
+			const resultInvalid = await executor.execute({
+				action: 'hover',
+				ref: '@e999',
+			})
+			expect(resultInvalid.success).toBe(false)
+		})
+
+		test('focus validates element ref', async () => {
+			const resultInvalid = await executor.execute({
+				action: 'focus',
+				ref: '@e999',
+			})
+			expect(resultInvalid.success).toBe(false)
+		})
+
+		test('fill validates element ref', async () => {
+			const resultInvalid = await executor.execute({
+				action: 'fill',
+				ref: '@e999',
+				value: 'test',
+			})
+			expect(resultInvalid.success).toBe(false)
+		})
+
+		test('select validates element ref', async () => {
+			const resultInvalid = await executor.execute({
+				action: 'select',
+				ref: '@e999',
+				value: 'option',
+			})
+			expect(resultInvalid.success).toBe(false)
+		})
+
+		test('check validates element ref', async () => {
+			const resultInvalid = await executor.execute({
+				action: 'check',
+				ref: '@e999',
+			})
+			expect(resultInvalid.success).toBe(false)
+		})
+
+		test('uncheck validates element ref', async () => {
+			const resultInvalid = await executor.execute({
+				action: 'uncheck',
+				ref: '@e999',
+			})
+			expect(resultInvalid.success).toBe(false)
+		})
+
+		test('upload validates element ref', async () => {
+			const resultInvalid = await executor.execute({
+				action: 'upload',
+				ref: '@e999',
+				files: ['./file.png'],
+			})
+			expect(resultInvalid.success).toBe(false)
+		})
+	})
+})

--- a/packages/server/tests/executors/fill.test.ts
+++ b/packages/server/tests/executors/fill.test.ts
@@ -13,6 +13,7 @@ import {
 	MockSessionManager,
 	createDefaultHandler,
 	createTestConfig,
+	simulateSnapshot,
 } from '../helpers/mock-managers'
 
 describe('fill action executor', () => {
@@ -21,7 +22,7 @@ describe('fill action executor', () => {
 	let pairedManager: MockPairedManager
 	let sessionManager: MockSessionManager
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		browserManager = new MockBrowserManager()
 		pairedManager = new MockPairedManager()
 		sessionManager = new MockSessionManager()
@@ -33,6 +34,9 @@ describe('fill action executor', () => {
 			sessionManager as unknown as Parameters<typeof ActionExecutor>[2],
 			createTestConfig(),
 		)
+
+		// Simulate taking a snapshot to enable element ref validation
+		await simulateSnapshot(executor)
 	})
 
 	describe('fill by element ref', () => {

--- a/packages/server/tests/executors/upload.test.ts
+++ b/packages/server/tests/executors/upload.test.ts
@@ -13,6 +13,7 @@ import {
 	MockSessionManager,
 	createDefaultHandler,
 	createTestConfig,
+	simulateSnapshot,
 } from '../helpers/mock-managers'
 
 describe('upload action executor', () => {
@@ -21,7 +22,7 @@ describe('upload action executor', () => {
 	let pairedManager: MockPairedManager
 	let sessionManager: MockSessionManager
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		browserManager = new MockBrowserManager()
 		pairedManager = new MockPairedManager()
 		sessionManager = new MockSessionManager()
@@ -33,6 +34,9 @@ describe('upload action executor', () => {
 			sessionManager as unknown as Parameters<typeof ActionExecutor>[2],
 			createTestConfig(),
 		)
+
+		// Simulate taking a snapshot to enable element ref validation
+		await simulateSnapshot(executor)
 	})
 
 	describe('single file upload', () => {

--- a/packages/server/tests/helpers/mock-managers.ts
+++ b/packages/server/tests/helpers/mock-managers.ts
@@ -192,6 +192,14 @@ export class MockPairedManager {
 		return this.executeHandler(action)
 	}
 
+	broadcastActionStart(): void {
+		// No-op for mock
+	}
+
+	broadcastActionEnd(): void {
+		// No-op for mock
+	}
+
 	handleOpen(): void {
 		// No-op for mock
 	}
@@ -319,8 +327,14 @@ export function createActionHandler(
 
 /**
  * Create a default handler that succeeds for common actions.
+ *
+ * @param options.interactiveCount - Number of interactive elements to return in snapshot (default: 1000)
  */
-export function createDefaultHandler(): SendHandler {
+export function createDefaultHandler(options?: {
+	interactiveCount?: number
+}): SendHandler {
+	const interactiveCount = options?.interactiveCount ?? 1000
+
 	return (command) => {
 		const action = command.action as string
 
@@ -364,8 +378,34 @@ export function createDefaultHandler(): SendHandler {
 			case 'evaluate':
 				return { success: true, data: { result: [] } }
 
+			case 'snapshot': {
+				// Build mock refs for the specified count
+				const refs: Record<string, unknown> = {}
+				for (let i = 1; i <= interactiveCount; i++) {
+					refs[String(i)] = { tag: 'button', text: `Element ${i}` }
+				}
+				return {
+					success: true,
+					data: {
+						snapshot: '<html><body>Mock snapshot</body></html>',
+						refs,
+					},
+				}
+			}
+
 			default:
 				return { success: true }
 		}
 	}
+}
+
+/**
+ * Helper to simulate taking a snapshot for testing.
+ * This sets the lastInteractiveCount in the executor.
+ */
+export async function simulateSnapshot(
+	executor: { execute: (action: { action: 'snap' }) => Promise<unknown> },
+	_count = 100,
+): Promise<void> {
+	await executor.execute({ action: 'snap' })
 }


### PR DESCRIPTION
Fixes #36

## Problem
Clicking a non-existent element ref (e.g., `@e99999999`) returned success
instead of an error, making it hard for agents to detect and recover from
invalid element references.

## Solution

### Server-side validation
- Track `lastInteractiveCount` from snapshots in ActionExecutor
- Pre-validate element refs before sending to agent-browser
- Return structured ELEMENT_NOT_FOUND errors with helpful messages:
  - "no snapshot taken yet" if no snap has been taken
  - "Last snap had N interactive elements (e1-eN)" if ref is out of range

### CLI error handling
- Check `result.success` before printing success messages
- Display structured error info (errorCode, suggestedFix)
- Set non-zero exit code on errors

## Changes
- packages/server/src/actions/executor.ts: Add validation to click, type,
  select, hover, focus, fill, check, uncheck, upload
- packages/cli/src/commands/interaction.ts: Add handleActionResult helper
- packages/server/tests/executors/element-ref-validation.test.ts: 25 new tests

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>