### PR TITLE
chore: add test:mcp script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"format": "biome format --write .",
 		"test": "bun test",
 		"test:cli": "./.claude/scripts/run-tests.sh --all",
+		"test:mcp": "./.claude/scripts/run-mcp-tests.sh --all",
 		"clean": "rm -rf packages/*/dist .scratch/testing",
 		"clean:test": "rm -rf .scratch/testing"
 	},


### PR DESCRIPTION
Add `test:mcp` script to package.json for running MCP server tests.

```bash
bun run test:mcp           # Run all MCP tests
bun run test:mcp -- schema-validation  # Run single category
```

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>