### PR TITLE
docs: fix outdated CLI command references

### DIFF
--- a/.agents/plans/v1/04-markers.md
+++ b/.agents/plans/v1/04-markers.md
@@ -1,5 +1,7 @@
 # 04 - Markers
 
+> **Historical Document**: This plan was written during initial development. The actual implementation may differ. See `CLAUDE.md` for current command reference.
+
 Implement the marker system for annotating browser views.
 
 ## Overview

--- a/.agents/plans/v1/05-mcp-cli.md
+++ b/.agents/plans/v1/05-mcp-cli.md
@@ -1,5 +1,7 @@
 # 05 - MCP & CLI
 
+> **Historical Document**: This plan was written during initial development. The actual implementation may differ. See `CLAUDE.md` for current command reference.
+
 Implement the MCP server and CLI for Navigator.
 
 ## Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Element refs use format `e{index}_{version}` (e.g., `e42_1`). Shorthand `e42` im
 
 **Workflow note**: Refs point to DOM elements by index. After page-changing actions (click, navigate), DOM may change - take a fresh snap if refs fail. Use shorthand (`e1`) to skip version validation.
 
-### Action Categories
+### Action Categories (MCP)
 
 Actions are validated via Zod discriminated union in `packages/core/src/schema/index.ts`:
 - Navigation: navigate, back, forward, reload

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We maintain a fork at [@outfitter/agent-browser](https://github.com/outfitter-de
 ## Features
 
 - **Single MCP tool** — One `navigator` tool with action routing (not 26+ separate tools)
-- **CLI** — `nav open`, `nav click`, `nav snap`, `nav mark`
+- **CLI** — `nav open`, `nav click`, `nav snap`, `nav marker`
 - **Paired mode** — Agent works in your browser via Chrome extension
 - **Markers** — Click to annotate, copy to agent with notes
 - **Sessions** — Auto-continuation within 30min, step logging
@@ -47,8 +47,9 @@ nav click @e1                 # Click element by ref
 nav type "#e2" "hello"        # Type into input
 
 # Markers
-nav mark ".pricing-card"      # Capture element as marker
-nav markers                   # List all markers
+nav marker set homepage        # Save current page as marker
+nav marker list                # List all markers
+nav marker read homepage       # Get marker content
 
 # Sessions
 nav session                   # Show current session

--- a/docs/cli-cleanup-codex-review.md
+++ b/docs/cli-cleanup-codex-review.md
@@ -1,5 +1,7 @@
 # CLI Cleanup Review (Codex)
 
+> **Note**: This document is a historical artifact from the command consolidation process (2026-01).
+
 This is a focused review of the proposed CLI cleanup with suggestions around grouping, discoverability, and long term ergonomics.
 
 ## 1) Command groupings (server, tab, mark)

--- a/docs/cli-cleanup.md
+++ b/docs/cli-cleanup.md
@@ -30,15 +30,15 @@ Consolidate and improve CLI command structure for consistency and discoverabilit
 
 Note: `nav tab <id>` works as shorthand for `nav tab switch <id>` since switching is the most common action.
 
-### `mark` subcommands ✅
+### `marker` subcommands ✅
 
 | Old | New | Status |
 |-----|-----|--------|
-| `mark` | `mark save` | ✅ Implemented |
-| `markers` | `mark list` | ✅ Implemented |
-| `marker <id>` | `mark get <id>` | ✅ Implemented |
-| `marker-compare <id1> <id2>` | `mark diff <id1> <id2>` | ✅ Implemented |
-| `marker-delete <id>` | `mark remove <id>` | ✅ Implemented |
+| `mark` | `marker set` | ✅ Implemented |
+| `markers` | `marker list` | ✅ Implemented |
+| `marker <id>` | `marker read <id>` | ✅ Implemented |
+| `marker-compare <id1> <id2>` | `marker compare <id1> <id2>` | ✅ Implemented |
+| `marker-delete <id>` | `marker remove <id>` | ✅ Implemented |
 
 ## Summary
 
@@ -48,7 +48,7 @@ Note: `nav tab <id>` works as shorthand for `nav tab switch <id>` since switchin
 nav install --plugin claude
 nav server start|stop|status
 nav tab list|switch|new|close
-nav mark save|list|get|diff|remove
+nav marker set|list|read|compare|remove
 nav clean
 nav doctor
 nav update


### PR DESCRIPTION
Update marker commands throughout documentation:
- README.md: nav mark → nav marker set, nav markers → nav marker list
- CLAUDE.md: clarify Action Categories as MCP actions
- docs/cli-cleanup.md: fix mark → marker subcommand names
- .agents/plans/v1/*.md: add historical disclaimers
- docs/cli-cleanup-codex-review.md: add historical note