### PR TITLE
feat(mcp): add 14 missing actions for CLI parity

### DIFF
--- a/packages/mcp/src/description.ts
+++ b/packages/mcp/src/description.ts
@@ -37,6 +37,8 @@ Selectors can be used instead of refs for most element actions: \`selector: ".bt
 - \`marker\`: capture element for visual regression
 - \`markers\`: list captured markers
 - \`markerGet\`, \`markerRead\`: retrieve marker details
+- \`markerCompare\`: compare two markers
+- \`markerDelete\`: delete a marker
 `
 }
 
@@ -45,12 +47,15 @@ function formatActionCategories(): string {
 		navigation: 'navigate(url), back, forward, reload',
 		tabs: 'tab(ref), tabs, newTab(url?), closeTab(ref)',
 		interaction:
-			'click(ref|selector), type(ref|selector, text), select(ref|selector, value), hover, scroll',
+			'click, type(text), select(value), hover, scroll, find(text|role|label), check, uncheck, upload(files), dialog(handler), press(key), fill(value), focus',
 		wait: 'waitFor(ref, state?), waitForNavigation, wait(ms)',
 		capture:
 			'snap(interactive?), screenshot(selector?, fullPage?), html(selector?), text(ref?)',
-		markers: 'marker(selector), markers, markerRead(id), markerGet(id)',
+		markers:
+			'marker(selector), markers, markerRead(id), markerGet(id), markerCompare(id1, id2), markerDelete(id)',
 		display: 'viewport(preset|width+height), colorScheme(scheme), mode(target)',
+		session: 'session, sessions(limit?), steps(sessionId?, limit?)',
+		evaluate: 'evaluate(script, args?)',
 	}
 
 	return Object.entries(ACTION_CATEGORIES)

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -91,8 +91,11 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
 							description: 'CSS selector for element actions',
 						},
 						// Interaction params
-						text: { type: 'string', description: 'Text for type action' },
-						value: { type: 'string', description: 'Select option value' },
+						text: { type: 'string', description: 'Text for type/find action' },
+						value: {
+							type: 'string',
+							description: 'Value for select/fill action',
+						},
 						button: {
 							type: 'string',
 							enum: ['left', 'right', 'middle'],
@@ -111,6 +114,61 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
 						delay: {
 							type: 'number',
 							description: 'Delay between keystrokes (ms)',
+						},
+						// Find params
+						exact: {
+							type: 'boolean',
+							description: 'Exact text match for find',
+						},
+						role: { type: 'string', description: 'ARIA role for find' },
+						label: { type: 'string', description: 'Form label text for find' },
+						placeholder: {
+							type: 'string',
+							description: 'Placeholder text for find',
+						},
+						testid: {
+							type: 'string',
+							description: 'data-testid attribute for find',
+						},
+						inRef: {
+							type: 'string',
+							description: 'Scope find within element ref',
+						},
+						inCss: {
+							type: 'string',
+							description: 'Scope find within CSS selector',
+						},
+						inTag: { type: 'string', description: 'Scope find within tag' },
+						tag: {
+							type: 'string',
+							description: 'Filter find results by tag name',
+						},
+						visible: {
+							type: 'boolean',
+							description: 'Filter find to visible elements',
+						},
+						enabled: {
+							type: 'boolean',
+							description: 'Filter find to enabled elements',
+						},
+						checked: {
+							type: 'boolean',
+							description: 'Filter find to checked elements',
+						},
+						// Press/Dialog/Upload params
+						key: {
+							type: 'string',
+							description: 'Key to press (e.g., Enter, Ctrl+s)',
+						},
+						files: {
+							type: 'array',
+							items: { type: 'string' },
+							description: 'File paths for upload',
+						},
+						handler: {
+							type: 'string',
+							enum: ['accept', 'dismiss', 'prompt', 'clear'],
+							description: 'Dialog handler',
 						},
 						// Scroll params
 						x: { type: 'number', description: 'Scroll X delta' },
@@ -176,6 +234,14 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
 						},
 						// Marker params
 						id: { type: 'string', description: 'Marker id' },
+						id1: {
+							type: 'string',
+							description: 'First marker ID for comparison',
+						},
+						id2: {
+							type: 'string',
+							description: 'Second marker ID for comparison',
+						},
 						name: { type: 'string', description: 'Marker name' },
 						tags: {
 							type: 'array',
@@ -194,6 +260,20 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
 						includeScreenshot: {
 							type: 'boolean',
 							description: 'Include screenshot in response',
+						},
+						// Evaluate params
+						script: {
+							type: 'string',
+							description: 'JavaScript to evaluate in page',
+						},
+						args: {
+							type: 'array',
+							description: 'Arguments for script',
+						},
+						// Session params
+						sessionId: {
+							type: 'string',
+							description: 'Session ID for steps query',
 						},
 					},
 					required: ['action'],

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -130,6 +130,101 @@ const scrollAction = z.object({
 	y: z.number().default(0).describe('Vertical scroll delta'),
 })
 
+const findAction = z.object({
+	action: z.literal('find'),
+	text: z.string().optional().describe('Text to search for'),
+	exact: z.boolean().optional().describe('Exact text match'),
+	role: z.string().optional().describe('ARIA role'),
+	label: z.string().optional().describe('Form label text'),
+	placeholder: z.string().optional().describe('Placeholder text'),
+	testid: z.string().optional().describe('data-testid attribute'),
+	ref: z
+		.string()
+		.regex(/^@?e\d+(_\d+)?$/)
+		.optional()
+		.describe('Element reference'),
+	inRef: z.string().optional().describe('Scope within element ref'),
+	inCss: z.string().optional().describe('Scope within CSS selector'),
+	inTag: z.string().optional().describe('Scope within tag'),
+	tag: z.string().optional().describe('Filter by tag name'),
+	visible: z.boolean().optional().describe('Filter to visible elements'),
+	enabled: z.boolean().optional().describe('Filter to enabled elements'),
+	checked: z.boolean().optional().describe('Filter to checked elements'),
+	tab: tabRefSchema.optional(),
+})
+
+const checkAction = z.object({
+	action: z.literal('check'),
+	ref: z
+		.string()
+		.regex(/^@?e\d+(_\d+)?$/)
+		.optional()
+		.describe('Checkbox element reference'),
+	selector: selectorSchema.optional(),
+	tab: tabRefSchema.optional(),
+})
+
+const uncheckAction = z.object({
+	action: z.literal('uncheck'),
+	ref: z
+		.string()
+		.regex(/^@?e\d+(_\d+)?$/)
+		.optional()
+		.describe('Checkbox element reference'),
+	selector: selectorSchema.optional(),
+	tab: tabRefSchema.optional(),
+})
+
+const uploadAction = z.object({
+	action: z.literal('upload'),
+	ref: z
+		.string()
+		.regex(/^@?e\d+(_\d+)?$/)
+		.optional()
+		.describe('File input element reference'),
+	selector: selectorSchema.optional(),
+	files: z.array(z.string()).min(1).describe('File paths to upload'),
+	tab: tabRefSchema.optional(),
+})
+
+const dialogAction = z.object({
+	action: z.literal('dialog'),
+	handler: z
+		.enum(['accept', 'dismiss', 'prompt', 'clear'])
+		.describe('Dialog handler action'),
+	text: z.string().optional().describe('Text for prompt dialog'),
+	tab: tabRefSchema.optional(),
+})
+
+const pressAction = z.object({
+	action: z.literal('press'),
+	key: z.string().min(1).describe('Key to press (e.g., Enter, Ctrl+s)'),
+	tab: tabRefSchema.optional(),
+})
+
+const fillAction = z.object({
+	action: z.literal('fill'),
+	ref: z
+		.string()
+		.regex(/^@?e\d+(_\d+)?$/)
+		.optional()
+		.describe('Input element reference'),
+	selector: selectorSchema.optional(),
+	value: z.string().describe('Value to fill'),
+	tab: tabRefSchema.optional(),
+})
+
+const focusAction = z.object({
+	action: z.literal('focus'),
+	ref: z
+		.string()
+		.regex(/^@?e\d+(_\d+)?$/)
+		.optional()
+		.describe('Element reference to focus'),
+	selector: selectorSchema.optional(),
+	tab: tabRefSchema.optional(),
+})
+
 // ============================================================================
 // Wait Actions
 // ============================================================================
@@ -244,6 +339,17 @@ const markerGetAction = z.object({
 	includeScreenshot: z.boolean().default(false),
 })
 
+const markerCompareAction = z.object({
+	action: z.literal('markerCompare'),
+	id1: z.string().uuid().describe('First marker ID'),
+	id2: z.string().uuid().describe('Second marker ID'),
+})
+
+const markerDeleteAction = z.object({
+	action: z.literal('markerDelete'),
+	id: z.string().uuid().describe('Marker ID to delete'),
+})
+
 // ============================================================================
 // Display Actions
 // ============================================================================
@@ -270,6 +376,36 @@ const modeAction = z.object({
 })
 
 // ============================================================================
+// Session Actions
+// ============================================================================
+
+const sessionAction = z.object({
+	action: z.literal('session'),
+})
+
+const sessionsAction = z.object({
+	action: z.literal('sessions'),
+	limit: z.number().int().min(1).optional().describe('Limit results'),
+})
+
+const stepsAction = z.object({
+	action: z.literal('steps'),
+	sessionId: z.string().uuid().optional().describe('Session ID'),
+	limit: z.number().int().min(1).optional().describe('Limit results'),
+})
+
+// ============================================================================
+// Evaluate Action
+// ============================================================================
+
+const evaluateAction = z.object({
+	action: z.literal('evaluate'),
+	script: z.string().min(1).describe('JavaScript to evaluate'),
+	args: z.array(z.unknown()).optional().describe('Arguments for script'),
+	tab: tabRefSchema.optional(),
+})
+
+// ============================================================================
 // Combined Action Schema (Single MCP Tool Pattern)
 // ============================================================================
 
@@ -291,6 +427,14 @@ export const navigatorActionSchema = z
 		selectAction,
 		hoverAction,
 		scrollAction,
+		findAction,
+		checkAction,
+		uncheckAction,
+		uploadAction,
+		dialogAction,
+		pressAction,
+		fillAction,
+		focusAction,
 		// Wait
 		waitForAction,
 		waitForNavigationAction,
@@ -305,13 +449,32 @@ export const navigatorActionSchema = z
 		markersAction,
 		markerReadAction,
 		markerGetAction,
+		markerCompareAction,
+		markerDeleteAction,
 		// Display
 		viewportAction,
 		colorSchemeAction,
 		modeAction,
+		// Session
+		sessionAction,
+		sessionsAction,
+		stepsAction,
+		// Evaluate
+		evaluateAction,
 	])
 	.superRefine((value, ctx) => {
-		const needsTarget = new Set(['click', 'type', 'select', 'hover', 'waitFor'])
+		const needsTarget = new Set([
+			'click',
+			'type',
+			'select',
+			'hover',
+			'waitFor',
+			'check',
+			'uncheck',
+			'upload',
+			'fill',
+			'focus',
+		])
 		if (!needsTarget.has(value.action)) {
 			return
 		}
@@ -341,11 +504,34 @@ export type NavigatorAction = z.infer<typeof navigatorActionSchema>
 export const ACTION_CATEGORIES = {
 	navigation: ['navigate', 'back', 'forward', 'reload'] as const,
 	tabs: ['tab', 'tabs', 'newTab', 'closeTab'] as const,
-	interaction: ['click', 'type', 'select', 'hover', 'scroll'] as const,
+	interaction: [
+		'click',
+		'type',
+		'select',
+		'hover',
+		'scroll',
+		'find',
+		'check',
+		'uncheck',
+		'upload',
+		'dialog',
+		'press',
+		'fill',
+		'focus',
+	] as const,
 	wait: ['waitFor', 'waitForNavigation', 'wait'] as const,
 	capture: ['snap', 'screenshot', 'html', 'text'] as const,
-	markers: ['marker', 'markers', 'markerRead', 'markerGet'] as const,
+	markers: [
+		'marker',
+		'markers',
+		'markerRead',
+		'markerGet',
+		'markerCompare',
+		'markerDelete',
+	] as const,
 	display: ['viewport', 'colorScheme', 'mode'] as const,
+	session: ['session', 'sessions', 'steps'] as const,
+	evaluate: ['evaluate'] as const,
 } as const
 
 export type ActionCategory = keyof typeof ACTION_CATEGORIES


### PR DESCRIPTION
## Summary

Adds 14 missing actions to the MCP server to achieve parity with the CLI.

Closes #54

## Changes

**Files modified:**
- `packages/mcp/src/schema.ts` - Added 14 Zod action schemas, updated ACTION_CATEGORIES
- `packages/mcp/src/index.ts` - Added inputSchema properties for new parameters
- `packages/mcp/src/description.ts` - Updated action descriptions

**Actions added:**

| Category | Actions |
|----------|---------|
| Interaction (8) | `find`, `check`, `uncheck`, `upload`, `dialog`, `press`, `fill`, `focus` |
| Markers (2) | `markerCompare`, `markerDelete` |
| Session (3) | `session`, `sessions`, `steps` |
| Evaluate (1) | `evaluate` |

## Notes

- All backend logic already existed in the server executor - this is schema/documentation only
- MCP schemas are slightly stricter than core (e.g., `.min(1)` on script, `.int()` on limit) - this is intentional
- 515 tests pass with 66 additional schema validation tests

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (515 tests)
- [x] Schema validation script passes (66 tests)
- [ ] Manual verification with MCP client

🤖 Generated with [Claude Code](https://claude.ai/code)