### PR TITLE
feat(mcp): add sequence action to MCP schema + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Actions are validated via Zod discriminated union in `packages/core/src/schema/i
 - Capture: screenshot, snap, html, text
 - Markers: marker, markers, markerGet, markerRead, markerCompare, etc.
 - Display: viewport, colorScheme, mode
+- Sequence: sequence (batch execution, see docs/sequences.md)
 - Routes: run, replay
 
 Canonical action exposure (CLI vs MCP) is defined in

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -278,6 +278,6 @@ Optional clicks (cookie banner, popups) may fail but the snap still executes.
 
 ## Related
 
-- [Element References](./element-refs.md) - How `e42` refs work
-- [Sessions](./sessions.md) - Session continuity and step logging
-- [Actions](./actions.md) - Full action reference
+- **Element References** - `e42` refs are documented in `CLAUDE.md` under "Element Reference System"
+- **Action Categories** - Full action list in `CLAUDE.md` under "Action Categories (MCP)"
+- **Architecture** - See `docs/architecture/DESIGN.md` for design philosophy

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -1,0 +1,283 @@
+# Sequences
+
+Sequences enable batch execution of multiple Navigator actions in a single call. This reduces round trips, minimizes context usage, and enables efficient multi-step workflows while maintaining full validation and logging for each step.
+
+## Overview
+
+A sequence is an array of typed actions executed in order. Each step is validated, logged, and can be parameterized with variables.
+
+```json
+{
+  "action": "sequence",
+  "steps": [
+    { "action": "navigate", "url": "https://example.com" },
+    { "action": "click", "selector": "button" },
+    { "action": "snap" }
+  ]
+}
+```
+
+## When to Use Sequences
+
+| Scenario | Without Sequences | With Sequences |
+|----------|-------------------|----------------|
+| Login flow (5 steps) | 5 MCP calls | 1 MCP call |
+| Form fill + submit | 4+ MCP calls | 1 MCP call |
+| Multi-page navigation | N calls | 1 call |
+
+Use sequences when:
+- You have a known series of actions to execute
+- Reducing round trips improves efficiency
+- Actions don't depend on inspecting intermediate results
+
+Don't use sequences when:
+- You need to inspect results between steps
+- Actions depend on dynamic element refs from previous snaps
+- You need conditional branching based on page state
+
+## Variable Interpolation
+
+Use `{{varName}}` syntax to parameterize action values:
+
+```json
+{
+  "action": "sequence",
+  "steps": [
+    { "action": "navigate", "url": "{{baseUrl}}/login" },
+    { "action": "fill", "selector": "#email", "value": "{{email}}" },
+    { "action": "fill", "selector": "#password", "value": "{{password}}" },
+    { "action": "click", "selector": "button[type='submit']" }
+  ],
+  "params": {
+    "baseUrl": "https://example.com",
+    "email": "user@example.com",
+    "password": "secret123"
+  }
+}
+```
+
+### Variable Rules
+
+- Variables use the pattern `{{varName}}`
+- Variable names must start with a letter or underscore
+- Missing variables are left as-is (not errors)
+- Non-string values are converted via `String()`
+- Variables can appear anywhere in string values
+
+## Error Handling
+
+### Stop on Error (Default)
+
+By default, sequences stop on the first error:
+
+```json
+{
+  "action": "sequence",
+  "steps": [
+    { "action": "navigate", "url": "https://example.com" },
+    { "action": "click", "selector": "#nonexistent" },
+    { "action": "snap" }
+  ]
+}
+```
+
+Result when step 2 fails:
+```json
+{
+  "success": false,
+  "completed": 2,
+  "total": 3,
+  "stoppedAt": 1,
+  "error": "Element not found: #nonexistent",
+  "steps": [
+    { "index": 0, "action": "navigate", "success": true, "duration": 1200 },
+    { "index": 1, "action": "click", "success": false, "error": "Element not found", "duration": 50 }
+  ]
+}
+```
+
+### Continue on Error
+
+Set `stopOnError: false` to continue executing remaining steps:
+
+```json
+{
+  "action": "sequence",
+  "steps": [
+    { "action": "click", "selector": "#optional-button" },
+    { "action": "snap" }
+  ],
+  "stopOnError": false
+}
+```
+
+The sequence completes all steps; `success` is `false` if any step failed.
+
+## Nested Sequences
+
+Sequences can contain other sequences (max depth: 3):
+
+```json
+{
+  "action": "sequence",
+  "name": "full-checkout",
+  "steps": [
+    {
+      "action": "sequence",
+      "name": "login",
+      "steps": [
+        { "action": "navigate", "url": "{{baseUrl}}/login" },
+        { "action": "fill", "selector": "#email", "value": "{{email}}" },
+        { "action": "click", "selector": "button[type='submit']" }
+      ]
+    },
+    {
+      "action": "sequence",
+      "name": "add-to-cart",
+      "steps": [
+        { "action": "navigate", "url": "{{baseUrl}}/products/{{productId}}" },
+        { "action": "click", "selector": ".add-to-cart" }
+      ],
+      "params": { "productId": "12345" }
+    }
+  ],
+  "params": {
+    "baseUrl": "https://shop.example.com",
+    "email": "user@example.com"
+  }
+}
+```
+
+Nested sequences:
+- Inherit parent params (inner params override outer)
+- Have their own `stopOnError` setting
+- Are logged as single steps in the parent result
+
+## Sequence Result
+
+Every sequence returns a structured result:
+
+```typescript
+interface SequenceResult {
+  success: boolean          // true if all steps succeeded
+  completed: number         // number of steps that ran
+  total: number             // total steps in sequence
+  steps: SequenceStepResult[]
+  stoppedAt?: number        // index where execution stopped (if stopOnError)
+  error?: string            // first error message
+}
+
+interface SequenceStepResult {
+  index: number             // 0-based step index
+  action: string            // action type (e.g., "click", "navigate")
+  success: boolean
+  error?: string
+  duration: number          // milliseconds
+}
+```
+
+## Logging
+
+Each step is logged to the session's step log (`step-log.jsonl`) with:
+- Timestamp
+- Action type
+- Success/failure status
+- Duration
+- Any error details
+
+This enables debugging and replay of sequence execution.
+
+## Examples
+
+### Login Flow
+
+```json
+{
+  "action": "sequence",
+  "name": "login",
+  "steps": [
+    { "action": "navigate", "url": "https://app.example.com/login" },
+    { "action": "fill", "selector": "#email", "value": "{{email}}" },
+    { "action": "fill", "selector": "#password", "value": "{{password}}" },
+    { "action": "click", "selector": "button[type='submit']" },
+    { "action": "waitFor", "selector": ".dashboard", "state": "visible" }
+  ],
+  "params": {
+    "email": "user@example.com",
+    "password": "secret"
+  }
+}
+```
+
+### Form Fill with Snap
+
+```json
+{
+  "action": "sequence",
+  "steps": [
+    { "action": "navigate", "url": "https://example.com/contact" },
+    { "action": "fill", "selector": "#name", "value": "{{name}}" },
+    { "action": "fill", "selector": "#email", "value": "{{email}}" },
+    { "action": "fill", "selector": "#message", "value": "{{message}}" },
+    { "action": "snap" }
+  ],
+  "params": {
+    "name": "Test User",
+    "email": "test@example.com",
+    "message": "Hello from Navigator!"
+  }
+}
+```
+
+### Multi-Tab Workflow
+
+```json
+{
+  "action": "sequence",
+  "steps": [
+    { "action": "navigate", "url": "https://docs.example.com", "tab": "b0" },
+    { "action": "newTab", "url": "https://app.example.com" },
+    { "action": "snap", "tab": "b0" },
+    { "action": "snap", "tab": "b1" }
+  ]
+}
+```
+
+### Resilient Scraping
+
+```json
+{
+  "action": "sequence",
+  "stopOnError": false,
+  "steps": [
+    { "action": "navigate", "url": "{{url}}" },
+    { "action": "click", "selector": ".cookie-dismiss" },
+    { "action": "click", "selector": ".popup-close" },
+    { "action": "snap" }
+  ],
+  "params": { "url": "https://example.com" }
+}
+```
+
+Optional clicks (cookie banner, popups) may fail but the snap still executes.
+
+## Limitations
+
+- **Max nesting depth**: 3 levels
+- **No conditionals**: Sequences execute linearly (use separate calls for branching)
+- **No loops**: Each step executes once
+- **Element refs**: Refs from snap are scoped to that step; subsequent steps can't use them directly
+
+## Surface Availability
+
+| Surface | Support |
+|---------|---------|
+| MCP | Yes |
+| CLI | Yes |
+| Server API | Yes |
+
+## Related
+
+- [Element References](./element-refs.md) - How `e42` refs work
+- [Sessions](./sessions.md) - Session continuity and step logging
+- [Actions](./actions.md) - Full action reference

--- a/packages/core/src/schema/action.ts
+++ b/packages/core/src/schema/action.ts
@@ -386,12 +386,36 @@ const stepsAction = z.object({
  * Enables Ami-style efficiency (fewer round trips) while maintaining
  * Navigator's safety guarantees (Zod validation, step logging).
  *
- * Note: Uses z.any() for steps array due to circular reference constraints
- * with discriminated unions. Runtime validation happens in SequenceExecutor.
+ * ## Design Decision: z.any() for steps
+ *
+ * We use `z.any()` instead of `z.lazy()` for the steps array. This is a
+ * deliberate tradeoff:
+ *
+ * **Why not z.lazy()?**
+ * - Zod's discriminatedUnion doesn't work with z.lazy() - we'd have to use
+ *   z.union() instead, losing the 'action' field optimization
+ * - z.union() produces worse error messages ("invalid input" vs specific action errors)
+ * - Would require restructuring the entire action schema
+ *
+ * **How validation still works:**
+ * - Each step IS validated at execution time via ActionExecutor
+ * - SequenceExecutor calls executeAction() for each step, which validates via Zod
+ * - Invalid steps fail with clear errors when that step executes
+ *
+ * **Tradeoff:**
+ * - Pro: Simple schema, discriminated union preserved, partial execution possible
+ * - Con: Malformed steps discovered mid-sequence rather than upfront
+ *
+ * If fail-fast behavior is needed, SequenceExecutor can optionally validate
+ * all steps upfront before execution (without schema changes).
  */
 const sequenceAction = z.object({
 	action: z.literal('sequence'),
-	/** Array of actions to execute in sequence */
+	/**
+	 * Array of actions to execute in sequence.
+	 * Uses z.any() at schema level; validated at execution time.
+	 * See class comment for design rationale.
+	 */
 	steps: z.array(z.any()).min(1),
 	/** Parameters for {{varName}} interpolation */
 	params: z.record(z.unknown()).optional(),

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -81,6 +81,7 @@ export {
 
 export {
 	MAX_SEQUENCE_DEPTH,
+	MAX_SEQUENCE_STEPS,
 	type SequenceOptions,
 	SequenceOptionsSchema,
 	type SequenceResult,

--- a/packages/core/src/schema/sequence.ts
+++ b/packages/core/src/schema/sequence.ts
@@ -94,6 +94,12 @@ export type SequenceOptions = z.infer<typeof SequenceOptionsSchema>
 /** Maximum nesting depth for sequences containing other sequences */
 export const MAX_SEQUENCE_DEPTH = 3
 
+/**
+ * Maximum number of steps allowed in a single sequence.
+ * Prevents DoS via extremely long sequences that could lock resources or flood logs.
+ */
+export const MAX_SEQUENCE_STEPS = 100
+
 // ============================================================================
 // Note on Sequence Input Schema
 // ============================================================================

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -425,13 +425,21 @@ const evaluateAction = z.object({
  *   ],
  *   params: { email: 'user@example.com' }
  * }
+ *
+ * Note: Steps use z.any() at schema level. This is a deliberate tradeoff -
+ * z.lazy() doesn't work with discriminatedUnion, and z.union() would produce
+ * worse error messages. Each step IS validated at execution time via the
+ * normal action validation path. See packages/core/src/schema/action.ts
+ * for detailed rationale.
  */
 const sequenceAction = z.object({
 	action: z.literal('sequence'),
 	steps: z
 		.array(z.any())
 		.min(1)
-		.describe('Array of actions to execute in sequence'),
+		.describe(
+			'Array of actions to execute in sequence (validated at execution time)',
+		),
 	params: z
 		.record(z.unknown())
 		.optional()

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -406,6 +406,44 @@ const evaluateAction = z.object({
 })
 
 // ============================================================================
+// Sequence Action
+// ============================================================================
+
+/**
+ * Sequence action for batch execution of multiple typed actions.
+ *
+ * Enables efficient multi-step workflows in a single MCP call while
+ * maintaining validation, logging, and error handling for each step.
+ *
+ * Example:
+ * {
+ *   action: 'sequence',
+ *   steps: [
+ *     { action: 'navigate', url: 'https://example.com' },
+ *     { action: 'click', selector: 'button' },
+ *     { action: 'snap' }
+ *   ],
+ *   params: { email: 'user@example.com' }
+ * }
+ */
+const sequenceAction = z.object({
+	action: z.literal('sequence'),
+	steps: z
+		.array(z.any())
+		.min(1)
+		.describe('Array of actions to execute in sequence'),
+	params: z
+		.record(z.unknown())
+		.optional()
+		.describe('Parameters for {{varName}} interpolation'),
+	stopOnError: z
+		.boolean()
+		.default(true)
+		.describe('Stop execution on first error'),
+	name: z.string().optional().describe('Optional name for logging'),
+})
+
+// ============================================================================
 // Combined Action Schema (Single MCP Tool Pattern)
 // ============================================================================
 
@@ -461,6 +499,8 @@ export const navigatorActionSchema = z
 		stepsAction,
 		// Evaluate
 		evaluateAction,
+		// Sequence
+		sequenceAction,
 	])
 	.superRefine((value, ctx) => {
 		const needsTarget = new Set([
@@ -532,6 +572,7 @@ export const ACTION_CATEGORIES = {
 	display: ['viewport', 'colorScheme', 'mode'] as const,
 	session: ['session', 'sessions', 'steps'] as const,
 	evaluate: ['evaluate'] as const,
+	sequence: ['sequence'] as const,
 } as const
 
 export type ActionCategory = keyof typeof ACTION_CATEGORIES

--- a/packages/server/src/sequences/executor.ts
+++ b/packages/server/src/sequences/executor.ts
@@ -9,10 +9,11 @@ import type { Action, ActionResult } from '@outfitter/navigator-core'
 import { CATEGORIES, getLogger } from '@outfitter/navigator-core/logging'
 import {
 	MAX_SEQUENCE_DEPTH,
+	MAX_SEQUENCE_STEPS,
 	type SequenceResult,
 	type SequenceStepResult,
 } from '@outfitter/navigator-core/schema'
-import { interpolateParams } from './params'
+import { interpolateParams, validateParams } from './params'
 
 const log = getLogger(CATEGORIES.ACTIONS)
 
@@ -82,9 +83,34 @@ export class SequenceExecutor {
 			return this.maxDepthError(steps.length)
 		}
 
+		// Step count guard (DoS protection)
+		if (steps.length > MAX_SEQUENCE_STEPS) {
+			return {
+				success: false,
+				completed: 0,
+				total: steps.length,
+				steps: [],
+				error: `Sequence exceeds maximum step count (${MAX_SEQUENCE_STEPS})`,
+			}
+		}
+
 		// Empty sequence is a no-op
 		if (steps.length === 0) {
 			return { success: true, completed: 0, total: 0, steps: [] }
+		}
+
+		// Validate all required variables are provided upfront (fail-fast)
+		if (params) {
+			const missing = validateParams(steps, params)
+			if (missing.length > 0) {
+				return {
+					success: false,
+					completed: 0,
+					total: steps.length,
+					steps: [],
+					error: `Missing required parameters: ${missing.join(', ')}`,
+				}
+			}
 		}
 
 		const seqName = name ?? 'sequence'

--- a/packages/server/src/sequences/params.ts
+++ b/packages/server/src/sequences/params.ts
@@ -4,31 +4,34 @@
  * Handles {{varName}} parameter substitution in action objects.
  */
 
-import { VARIABLE_PATTERN } from '@outfitter/navigator-core/schema'
+/**
+ * Variable pattern: {{varName}}
+ *
+ * Note: We define a fresh regex here rather than importing VARIABLE_PATTERN
+ * from the schema. The schema exports a global RegExp with /g flag, which
+ * has mutable lastIndex state that can cause race conditions in concurrent
+ * async operations. Using matchAll() or creating fresh instances avoids this.
+ */
+const VARIABLE_REGEX_SOURCE = /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/g
 
 /**
  * Check if a string contains variable placeholders.
  */
 export function hasVariables(str: string): boolean {
-	VARIABLE_PATTERN.lastIndex = 0 // Reset regex state
-	return VARIABLE_PATTERN.test(str)
+	// Create fresh regex to avoid global state issues
+	return new RegExp(VARIABLE_REGEX_SOURCE.source).test(str)
 }
 
 /**
  * Extract variable names from a string.
+ * Uses matchAll() to avoid global regex state issues.
  */
 export function extractVariables(str: string): string[] {
-	const vars: string[] = []
-	VARIABLE_PATTERN.lastIndex = 0
-	let match = VARIABLE_PATTERN.exec(str)
-	while (match !== null) {
-		const varName = match[1]
-		if (varName !== undefined) {
-			vars.push(varName)
-		}
-		match = VARIABLE_PATTERN.exec(str)
-	}
-	return vars
+	// matchAll returns an iterator - safe for concurrent use
+	const matches = str.matchAll(new RegExp(VARIABLE_REGEX_SOURCE.source, 'g'))
+	return Array.from(matches, (m) => m[1]).filter(
+		(v): v is string => v !== undefined,
+	)
 }
 
 /**
@@ -40,8 +43,8 @@ export function interpolateString(
 	str: string,
 	params: Record<string, unknown>,
 ): string {
-	VARIABLE_PATTERN.lastIndex = 0
-	return str.replace(VARIABLE_PATTERN, (match, varName: string) => {
+	// String.replace with regex is safe - doesn't use lastIndex
+	return str.replace(VARIABLE_REGEX_SOURCE, (match, varName: string) => {
 		if (varName in params) {
 			const value = params[varName]
 			return typeof value === 'string' ? value : String(value)
@@ -120,6 +123,9 @@ export function validateParams(
 
 /**
  * Internal recursive variable collection.
+ *
+ * Note: Skips nested sequences (action: 'sequence') because they have their
+ * own params and validate themselves when they execute.
  */
 function collectMissingVariables(
 	value: unknown,
@@ -143,7 +149,14 @@ function collectMissingVariables(
 	}
 
 	if (value !== null && typeof value === 'object') {
-		for (const val of Object.values(value)) {
+		const obj = value as Record<string, unknown>
+
+		// Skip nested sequences - they validate themselves with merged params
+		if (obj.action === 'sequence') {
+			return
+		}
+
+		for (const val of Object.values(obj)) {
 			collectMissingVariables(val, params, missing)
 		}
 	}

--- a/packages/server/src/sequences/params.ts
+++ b/packages/server/src/sequences/params.ts
@@ -44,8 +44,9 @@ export function interpolateString(
 	params: Record<string, unknown>,
 ): string {
 	// String.replace with regex is safe - doesn't use lastIndex
+	// Use Object.hasOwn to avoid prototype pollution (e.g., {{__proto__}})
 	return str.replace(VARIABLE_REGEX_SOURCE, (match, varName: string) => {
-		if (varName in params) {
+		if (Object.hasOwn(params, varName)) {
 			const value = params[varName]
 			return typeof value === 'string' ? value : String(value)
 		}
@@ -134,7 +135,8 @@ function collectMissingVariables(
 ): void {
 	if (typeof value === 'string') {
 		for (const varName of extractVariables(value)) {
-			if (!(varName in params)) {
+			// Use Object.hasOwn to avoid prototype pollution (e.g., {{constructor}})
+			if (!Object.hasOwn(params, varName)) {
 				missing.push(varName)
 			}
 		}

--- a/packages/server/tests/sequences/executor.test.ts
+++ b/packages/server/tests/sequences/executor.test.ts
@@ -308,5 +308,42 @@ describe('SequenceExecutor', () => {
 			expect(result.stoppedAt).toBe(0)
 			expect(calls).toHaveLength(1) // Second action not executed
 		})
+
+		test('fails fast on missing required parameters', async () => {
+			const { execute, calls } = createMockExecutor([{ success: true }])
+			const executor = new SequenceExecutor(execute)
+
+			const steps: Action[] = [
+				{ action: 'fill', selector: '#email', value: '{{email}}' } as Action,
+				{ action: 'fill', selector: '#name', value: '{{name}}' } as Action,
+			]
+
+			const result = await executor.execute(steps, {
+				params: { email: 'test@example.com' }, // Missing 'name'
+			})
+
+			expect(result.success).toBe(false)
+			expect(result.completed).toBe(0)
+			expect(result.error).toContain('Missing required parameters')
+			expect(result.error).toContain('name')
+			expect(calls).toHaveLength(0) // No actions should have executed
+		})
+
+		test('rejects sequences exceeding max step count', async () => {
+			const { execute, calls } = createMockExecutor([])
+			const executor = new SequenceExecutor(execute)
+
+			// Create a sequence with 101 steps (over the limit of 100)
+			const steps: Action[] = Array.from({ length: 101 }, (_, i) => ({
+				action: 'snap',
+			})) as Action[]
+
+			const result = await executor.execute(steps)
+
+			expect(result.success).toBe(false)
+			expect(result.completed).toBe(0)
+			expect(result.error).toContain('maximum step count')
+			expect(calls).toHaveLength(0)
+		})
 	})
 })

--- a/packages/server/tests/sequences/mcp-schema.test.ts
+++ b/packages/server/tests/sequences/mcp-schema.test.ts
@@ -1,0 +1,141 @@
+/**
+ * MCP Schema Tests for Sequence Action
+ *
+ * Tests that sequence actions parse correctly through the MCP schema.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { navigatorActionSchema } from '../../../mcp/src/schema'
+
+describe('MCP Schema - Sequence Action', () => {
+	test('parses simple sequence', () => {
+		const input = {
+			action: 'sequence',
+			steps: [
+				{ action: 'navigate', url: 'https://example.com' },
+				{ action: 'snap' },
+			],
+		}
+
+		const result = navigatorActionSchema.safeParse(input)
+		expect(result.success).toBe(true)
+		if (result.success) {
+			expect(result.data.action).toBe('sequence')
+		}
+	})
+
+	test('parses sequence with params', () => {
+		const input = {
+			action: 'sequence',
+			steps: [
+				{ action: 'type', selector: '#email', text: '{{email}}' },
+				{ action: 'click', selector: 'button[type="submit"]' },
+			],
+			params: { email: 'test@example.com' },
+		}
+
+		const result = navigatorActionSchema.safeParse(input)
+		expect(result.success).toBe(true)
+		if (result.success) {
+			expect(result.data.action).toBe('sequence')
+			expect(
+				(result.data as { params?: Record<string, unknown> }).params,
+			).toEqual({
+				email: 'test@example.com',
+			})
+		}
+	})
+
+	test('parses sequence with stopOnError', () => {
+		const input = {
+			action: 'sequence',
+			steps: [{ action: 'navigate', url: 'https://example.com' }],
+			stopOnError: false,
+		}
+
+		const result = navigatorActionSchema.safeParse(input)
+		expect(result.success).toBe(true)
+		if (result.success) {
+			expect((result.data as { stopOnError: boolean }).stopOnError).toBe(false)
+		}
+	})
+
+	test('parses sequence with name', () => {
+		const input = {
+			action: 'sequence',
+			steps: [{ action: 'snap' }],
+			name: 'test-sequence',
+		}
+
+		const result = navigatorActionSchema.safeParse(input)
+		expect(result.success).toBe(true)
+		if (result.success) {
+			expect((result.data as { name?: string }).name).toBe('test-sequence')
+		}
+	})
+
+	test('rejects empty steps array', () => {
+		const input = {
+			action: 'sequence',
+			steps: [],
+		}
+
+		const result = navigatorActionSchema.safeParse(input)
+		expect(result.success).toBe(false)
+	})
+
+	test('rejects missing steps', () => {
+		const input = {
+			action: 'sequence',
+		}
+
+		const result = navigatorActionSchema.safeParse(input)
+		expect(result.success).toBe(false)
+	})
+
+	test('defaults stopOnError to true', () => {
+		const input = {
+			action: 'sequence',
+			steps: [{ action: 'snap' }],
+		}
+
+		const result = navigatorActionSchema.safeParse(input)
+		expect(result.success).toBe(true)
+		if (result.success) {
+			expect((result.data as { stopOnError: boolean }).stopOnError).toBe(true)
+		}
+	})
+
+	test('parses complex multi-step sequence', () => {
+		const input = {
+			action: 'sequence',
+			steps: [
+				{ action: 'navigate', url: 'https://example.com/login' },
+				{ action: 'fill', selector: '#email', value: '{{email}}' },
+				{ action: 'fill', selector: '#password', value: '{{password}}' },
+				{ action: 'click', selector: 'button[type="submit"]' },
+				{ action: 'waitFor', selector: '.dashboard', state: 'visible' },
+				{ action: 'snap' },
+			],
+			params: {
+				email: 'user@example.com',
+				password: 'secret',
+			},
+			name: 'login-flow',
+		}
+
+		const result = navigatorActionSchema.safeParse(input)
+		expect(result.success).toBe(true)
+		if (result.success) {
+			expect(result.data.action).toBe('sequence')
+			const data = result.data as {
+				steps: unknown[]
+				params: Record<string, unknown>
+				name: string
+			}
+			expect(data.steps.length).toBe(6)
+			expect(data.params.email).toBe('user@example.com')
+			expect(data.name).toBe('login-flow')
+		}
+	})
+})

--- a/packages/server/tests/sequences/params.test.ts
+++ b/packages/server/tests/sequences/params.test.ts
@@ -198,3 +198,28 @@ describe('validateParams', () => {
 		expect(validateParams(data, {})).toEqual(['deep'])
 	})
 })
+
+describe('prototype pollution protection', () => {
+	test('does not interpolate prototype properties like __proto__', () => {
+		const result = interpolateString('{{__proto__}}', {})
+		expect(result).toBe('{{__proto__}}') // Left as-is, not Object.prototype
+	})
+
+	test('does not interpolate constructor', () => {
+		const result = interpolateString('{{constructor}}', {})
+		expect(result).toBe('{{constructor}}')
+	})
+
+	test('reports __proto__ as missing even though it exists on prototype', () => {
+		const missing = validateParams({ x: '{{__proto__}}' }, {})
+		expect(missing).toEqual(['__proto__'])
+	})
+
+	test('only interpolates own properties', () => {
+		const params = Object.create({ inherited: 'bad' })
+		params.own = 'good'
+
+		const result = interpolateString('{{own}} {{inherited}}', params)
+		expect(result).toBe('good {{inherited}}')
+	})
+})


### PR DESCRIPTION
## Summary

Complete the sequence system by adding MCP schema support and comprehensive documentation.

**MCP Schema:**
- Add `sequenceAction` to `packages/mcp/src/schema.ts` discriminated union
- Add `sequence` to `ACTION_CATEGORIES`
- Add 8 MCP schema parsing tests

**Documentation:**
- Create `docs/sequences.md` with full documentation:
  - Overview and when to use sequences
  - Variable interpolation (`{{varName}}` syntax)
  - Error handling (`stopOnError`)
  - Nested sequences (max depth: 3)
  - Result structure
  - Multiple examples (login, forms, multi-tab, resilient scraping)
  - Limitations
- Update `CLAUDE.md` with sequence action category

## Test plan

- [x] `bun test packages/server/tests/sequences/` - 49 tests pass
- [x] TypeScript compiles without errors
- [x] Lint passes

Part 5 of 5 in the sequences stack. **This completes Phase 1 of the sequence system.**

🤖 Generated with [Claude Code](https://claude.ai/code)