### PR TITLE
feat(cli,mcp): add sequence command and improve agent discoverability

### DIFF
--- a/packages/cli/src/commands/sequence.ts
+++ b/packages/cli/src/commands/sequence.ts
@@ -1,0 +1,146 @@
+/**
+ * Sequence Command
+ *
+ * Execute multiple actions in sequence with variable interpolation.
+ */
+
+import { readFileSync } from 'node:fs'
+import type { Command } from 'commander'
+import type { NavigatorClient } from '../client.js'
+
+interface SequenceStepResult {
+	index: number
+	action: string
+	success: boolean
+	duration: number
+	error?: string
+}
+
+interface SequenceResult {
+	success: boolean
+	error?: string
+	data?: {
+		success: boolean
+		completed: number
+		total: number
+		steps: SequenceStepResult[]
+		stoppedAt?: number
+		error?: string
+	}
+}
+
+export function registerSequenceCommand(
+	program: Command,
+	getClient: () => NavigatorClient,
+): void {
+	program
+		.command('sequence <file-or-json>')
+		.description('Execute a sequence of actions from file or inline JSON')
+		.option(
+			'--params <json>',
+			'Parameters for variable interpolation (JSON object)',
+		)
+		.option(
+			'--stop-on-error',
+			'Stop execution on first error (overrides JSON, default: true)',
+		)
+		.option('--no-stop-on-error', 'Continue execution on errors')
+		.action(
+			async (
+				fileOrJson: string,
+				options: { params?: string; stopOnError?: boolean },
+			) => {
+				const client = getClient()
+
+				try {
+					// Determine if input is a file path or inline JSON
+					let sequenceData: {
+						steps: unknown[]
+						params?: Record<string, unknown>
+						stopOnError?: boolean
+					}
+
+					if (fileOrJson.startsWith('{') || fileOrJson.startsWith('[')) {
+						// Inline JSON
+						const parsed = JSON.parse(fileOrJson)
+						sequenceData = Array.isArray(parsed)
+							? { steps: parsed }
+							: {
+									steps: parsed.steps ?? parsed,
+									params: parsed.params,
+									stopOnError: parsed.stopOnError,
+								}
+					} else {
+						// File path
+						const content = readFileSync(fileOrJson, 'utf8')
+						const parsed = JSON.parse(content)
+						sequenceData = Array.isArray(parsed)
+							? { steps: parsed }
+							: {
+									steps: parsed.steps ?? parsed,
+									params: parsed.params,
+									stopOnError: parsed.stopOnError,
+								}
+					}
+
+					// Merge CLI params with file params (CLI takes precedence)
+					let params = sequenceData.params ?? {}
+					if (options.params) {
+						const cliParams = JSON.parse(options.params)
+						params = { ...params, ...cliParams }
+					}
+
+					// CLI flag overrides JSON, JSON overrides default (true)
+					const stopOnError =
+						options.stopOnError ?? sequenceData.stopOnError ?? true
+
+					const result = await client.execute<SequenceResult>({
+						action: 'sequence',
+						steps: sequenceData.steps,
+						params: Object.keys(params).length > 0 ? params : undefined,
+						stopOnError,
+					})
+
+					if (result.success && result.data) {
+						const { data } = result
+
+						console.log(
+							`Sequence ${data.completed === data.total ? 'completed' : 'stopped'}: ${data.completed}/${data.total} steps`,
+						)
+
+						for (const step of data.steps) {
+							const status = step.success ? '✓' : '✗'
+							const duration = `${step.duration}ms`
+							const error = step.error ? ` - ${step.error}` : ''
+							console.log(
+								`  ${status} [${step.index}] ${step.action} (${duration})${error}`,
+							)
+						}
+
+						if (data.stoppedAt !== undefined) {
+							console.log(`\nStopped at step ${data.stoppedAt}`)
+						}
+					} else {
+						console.error('Sequence failed:', result.error)
+						process.exitCode = 1
+					}
+				} catch (err) {
+					if (err instanceof SyntaxError) {
+						console.error('Invalid JSON:', err.message)
+					} else if (
+						err instanceof Error &&
+						'code' in err &&
+						err.code === 'ENOENT'
+					) {
+						console.error('File not found:', fileOrJson)
+					} else {
+						console.error(
+							'Error:',
+							err instanceof Error ? err.message : String(err),
+						)
+					}
+					process.exitCode = 1
+				}
+			},
+		)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { registerDoctorCommand } from './commands/doctor.js'
 import { registerInteractionCommands } from './commands/interaction.js'
 import { registerMarkerCommands } from './commands/markers.js'
 import { registerNavigationCommands } from './commands/navigation.js'
+import { registerSequenceCommand } from './commands/sequence.js'
 import { registerServerCommands } from './commands/server.js'
 import { registerSessionCommands } from './commands/session.js'
 import { registerTabCommands } from './commands/tabs.js'
@@ -111,6 +112,9 @@ registerTabCommands(program, getClient)
 
 // Session: session, steps
 registerSessionCommands(program, getClient)
+
+// Sequence: sequence
+registerSequenceCommand(program, getClient)
 
 // Server: server start|status|stop
 registerServerCommands(program, getClient)

--- a/packages/mcp/src/description.ts
+++ b/packages/mcp/src/description.ts
@@ -40,6 +40,12 @@ Selectors can be used instead of refs for most element actions: \`selector: ".bt
 - \`markerGet\`, \`markerRead\`: retrieve marker details
 - \`markerCompare\`: compare two markers
 - \`markerDelete\`: delete a marker
+
+**Sequences**:
+Execute multiple actions in one call with \`{{var}}\` interpolation:
+\`\`\`json
+{"action":"sequence","steps":[{"action":"navigate","url":"{{url}}"},{"action":"snap"}],"params":{"url":"https://..."},"stopOnError":true}
+\`\`\`
 `
 }
 
@@ -86,6 +92,7 @@ function formatActionCategories(): string {
 		sessions: 'sessions(limit?)',
 		steps: 'steps(sessionId?, limit?)',
 		evaluate: 'evaluate(script, args?)',
+		sequence: 'sequence(steps[], params?, stopOnError?)',
 	}
 
 	const mcpActions = new Set(getActionsForSurface('mcp'))


### PR DESCRIPTION
## Summary

Completes CLI/MCP parity for the sequences feature:

- **CLI command**: `nav sequence <file-or-json>` with `--params` for variable override and `--stop-on-error` control
- **MCP description**: Adds sequence documentation to tool description so agents can discover the JSON schema

## Changes

- `packages/cli/src/commands/sequence.ts` - New CLI command
- `packages/cli/src/index.ts` - Register the command
- `packages/mcp/src/description.ts` - Add sequence to actionDocs and tool description

## Usage

```bash
# From file
nav sequence ./steps.json

# With param override
nav sequence ./steps.json --params '{"url":"https://..."}'

# Continue on errors
nav sequence ./steps.json --no-stop-on-error
```

## Agent Discoverability

Agents now see in the MCP tool description:
```
**Sequences**:
Execute multiple actions in one call with `{{var}}` interpolation:
{"action":"sequence","steps":[{"action":"navigate","url":"{{url}}"},{"action":"snap"}],"params":{"url":"https://..."},"stopOnError":true}
```

## Test Plan

- [x] `nav sequence --help` shows usage
- [x] File-based sequence execution works
- [x] `--params` override works  
- [x] `--stop-on-error` / `--no-stop-on-error` work
- [x] Typecheck passes
- [x] Lint passes (warnings only)
- [x] 606 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)