### PR TITLE
chore(deps): update agent-browser to v0.8.4

### DIFF
--- a/.claude/commands/agent-browser/check.md
+++ b/.claude/commands/agent-browser/check.md
@@ -25,4 +25,4 @@ $ARGUMENTS
 
 ### Current Status
 
-!`bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1`
+!`( cd "$(git rev-parse --show-toplevel)" && bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1 )`

--- a/.claude/commands/agent-browser/diff.md
+++ b/.claude/commands/agent-browser/diff.md
@@ -75,4 +75,4 @@ cat .agent-browser/analysis/$SHA/diffs/protocol.ts.diff
 
 ## Script
 
-!`bun run .claude/skills/agent-browser-upstream/scripts/generate-diff.ts $ARGUMENTS 2>&1`
+!`( cd "$(git rev-parse --show-toplevel)" && bun run .claude/skills/agent-browser-upstream/scripts/generate-diff.ts $ARGUMENTS 2>&1 )`

--- a/.claude/commands/agent-browser/integrate-changes.md
+++ b/.claude/commands/agent-browser/integrate-changes.md
@@ -40,4 +40,4 @@ $ARGUMENTS
 
 ### Current Status
 
-!`bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1`
+!`( cd "$(git rev-parse --show-toplevel)" && bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1 )`

--- a/.claude/commands/agent-browser/sync.md
+++ b/.claude/commands/agent-browser/sync.md
@@ -35,4 +35,4 @@ $ARGUMENTS
 
 ### Current Status
 
-!`bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1`
+!`( cd "$(git rev-parse --show-toplevel)" && bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1 )`

--- a/.claude/commands/agent-browser/update.md
+++ b/.claude/commands/agent-browser/update.md
@@ -26,4 +26,4 @@ $ARGUMENTS
 
 ### Current Status
 
-!`bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1`
+!`( cd "$(git rev-parse --show-toplevel)" && bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1 )`

--- a/.claude/commands/flow/agent-browser.md
+++ b/.claude/commands/flow/agent-browser.md
@@ -28,4 +28,4 @@ $ARGUMENTS
 
 ### Current Status
 
-!`bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1`
+!`( cd "$(git rev-parse --show-toplevel)" && bun run .claude/skills/agent-browser-upstream/scripts/analyze-upstream.ts --format summary 2>&1 )`

--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@logtape/hono": "^2.0.0",
-        "@outfitter/agent-browser": "github:outfitter-dev/agent-browser#v0.6.1-nav.1",
+        "@outfitter/agent-browser": "github:outfitter-dev/agent-browser#v0.8.4-nav.1",
         "@outfitter/navigator-core": "workspace:*",
         "hono": "^4.7.1",
         "zod": "^3.24.1",
@@ -243,7 +243,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@outfitter/agent-browser": ["agent-browser@github:outfitter-dev/agent-browser#5a19209", { "dependencies": { "playwright-core": "^1.57.0", "ws": "^8.19.0", "zod": "^3.22.4" }, "bin": { "agent-browser": "./bin/agent-browser" } }, "outfitter-dev-agent-browser-5a19209"],
+    "@outfitter/agent-browser": ["agent-browser@github:outfitter-dev/agent-browser#e89d086", { "dependencies": { "playwright-core": "^1.57.0", "ws": "^8.19.0", "zod": "^3.22.4" }, "bin": { "agent-browser": "./bin/agent-browser.js" } }, "outfitter-dev-agent-browser-e89d086"],
 
     "@outfitter/navigator-agents": ["@outfitter/navigator-agents@workspace:packages/agents"],
 
@@ -801,6 +801,10 @@
 
     "@babel/core/convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "@outfitter/navigator-core/@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
+
+    "@outfitter/navigator-server/@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -826,5 +830,9 @@
     "vite/rollup": ["rollup@4.56.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.56.0", "@rollup/rollup-android-arm64": "4.56.0", "@rollup/rollup-darwin-arm64": "4.56.0", "@rollup/rollup-darwin-x64": "4.56.0", "@rollup/rollup-freebsd-arm64": "4.56.0", "@rollup/rollup-freebsd-x64": "4.56.0", "@rollup/rollup-linux-arm-gnueabihf": "4.56.0", "@rollup/rollup-linux-arm-musleabihf": "4.56.0", "@rollup/rollup-linux-arm64-gnu": "4.56.0", "@rollup/rollup-linux-arm64-musl": "4.56.0", "@rollup/rollup-linux-loong64-gnu": "4.56.0", "@rollup/rollup-linux-loong64-musl": "4.56.0", "@rollup/rollup-linux-ppc64-gnu": "4.56.0", "@rollup/rollup-linux-ppc64-musl": "4.56.0", "@rollup/rollup-linux-riscv64-gnu": "4.56.0", "@rollup/rollup-linux-riscv64-musl": "4.56.0", "@rollup/rollup-linux-s390x-gnu": "4.56.0", "@rollup/rollup-linux-x64-gnu": "4.56.0", "@rollup/rollup-linux-x64-musl": "4.56.0", "@rollup/rollup-openbsd-x64": "4.56.0", "@rollup/rollup-openharmony-arm64": "4.56.0", "@rollup/rollup-win32-arm64-msvc": "4.56.0", "@rollup/rollup-win32-ia32-msvc": "4.56.0", "@rollup/rollup-win32-x64-gnu": "4.56.0", "@rollup/rollup-win32-x64-msvc": "4.56.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "@outfitter/navigator-core/@types/bun/bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
+
+    "@outfitter/navigator-server/@types/bun/bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@logtape/hono": "^2.0.0",
-		"@outfitter/agent-browser": "github:outfitter-dev/agent-browser#v0.6.1-nav.1",
+		"@outfitter/agent-browser": "github:outfitter-dev/agent-browser#v0.8.4-nav.1",
 		"@outfitter/navigator-core": "workspace:*",
 		"hono": "^4.7.1",
 		"zod": "^3.24.1"


### PR DESCRIPTION
## Summary

Updates @outfitter/agent-browser fork to sync with upstream v0.8.4 (50 commits).

## Upstream Changes

| Category | Count |
|----------|-------|
| Breaking | 0 |
| Additive | 2 |
| Fixes | 10 |
| Other | 38 |

### New Features
- **Kernel cloud browser provider** - New provider option (`-p kernel`)
- **Ignore HTTPS certificate errors** - `--ignore-https-errors` flag

### Security
- Cross-origin connection rejection for daemon/stream server

### Bug Fixes
- Daemon not found fix
- CLI binary permissions (pnpm/bun)
- Tab list fix for pages opened via clicks
- HiDPI screenshot fix (deviceScaleFactor)
- State/profile persistence fix

## Test Plan

- [x] Fork tests pass (196 passed)
- [x] Navigator tests pass (606 passed)
- [x] Lockfile updated

🤖 Generated with [Claude Code](https://claude.ai/code)